### PR TITLE
r-base to 3.6, default off (spia, fgsea, goatools), fix sleuth RAM problem

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -30,19 +30,19 @@ diffexp:
 enrichment:
   goatools:
     # tool is only run if set to `true`
-    activate: false
+    activate: true
     fdr_genes: 0.05
     fdr_go_terms: 0.05
   fgsea:
     gene_sets_file: "data/ref/dummy.gmt"
     # tool is only run if set to `true`
-    activate: false
+    activate: true
     # if activated, you need to provide a GMT file with gene sets of interest
     fdr_gene_set: 0.05
     nperm: 10000
   spia:
     # tool is only run if set to `true`
-    activate: false
+    activate: true
     # pathway database to use in SPIA, needs to be available for
     # the species specified by resources -> ref -> species above
     pathway_database: "panther"

--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -20,7 +20,7 @@ diffexp:
   exclude:
   # model for sleuth differential expression analysis
   models:
-    model_X: 
+    model_X:
       full: ~condition + batch_effect
       reduced: ~batch_effect
       # Binary valued covariate that shall be used for fold change/effect size
@@ -28,14 +28,21 @@ diffexp:
       primary_variable: condition
 
 enrichment:
-  gene_sets_file: "data/ref/dummy.gmt"
   goatools:
+    # tool is only run if set to `true`
+    activate: false
     fdr_genes: 0.05
     fdr_go_terms: 0.05
   fgsea:
+    gene_sets_file: "data/ref/dummy.gmt"
+    # tool is only run if set to `true`
+    activate: false
+    # if activated, you need to provide a GMT file with gene sets of interest
     fdr_gene_set: 0.05
     nperm: 10000
   spia:
+    # tool is only run if set to `true`
+    activate: false
     # pathway database to use in SPIA, needs to be available for
     # the species specified by resources -> ref -> species above
     pathway_database: "panther"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -36,12 +36,13 @@ enrichment:
   fgsea:
     # tool is only run if set to `true`
     activate: false
+    # if activated, you need to provide a GMT file with gene sets of interest
     gene_sets_file: "resources/gene_sets/dummy.gmt"
     fdr_gene_set: 0.05
     nperm: 100000
   spia:
     # tool is only run if set to `true`
-    activate: true
+    activate: false
     # pathway database to use in SPIA, needs to be available for
     # the species specified by resources -> ref -> species above
     pathway_database: "reactome"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -29,13 +29,19 @@ diffexp:
 
 enrichment:
   goatools:
+    # tool is only run if set to `true`
+    activate: false
     fdr_genes: 0.05
     fdr_go_terms: 0.05
   fgsea:
+    # tool is only run if set to `true`
+    activate: false
     gene_sets_file: "resources/gene_sets/dummy.gmt"
     fdr_gene_set: 0.05
     nperm: 100000
   spia:
+    # tool is only run if set to `true`
+    activate: true
     # pathway database to use in SPIA, needs to be available for
     # the species specified by resources -> ref -> species above
     pathway_database: "reactome"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,9 +3,9 @@ units: config/units.tsv
 
 resources:
   ref:
-    transcriptome: "resources/ref/Mus_musculus.GRCm38.cdna.all.plus_RUNX1a_GFP.fa"
+    transcriptome: "resources/ref/Homo_sapiens.GRCh38.cdna.chr21.fa"
     # species needs to be an identifier known to biomart, e.g. mmusculus, hsapiens
-    species: mmusculus
+    species: hsapiens
   ontology:
     # gene ontology to download, used e.g. in goatools
     gene_ontology: "http://current.geneontology.org/ontology/go-basic.obo"
@@ -20,7 +20,7 @@ diffexp:
   exclude:
   # model for sleuth differential expression analysis
   models:
-    model_X: 
+    model_X:
       full: ~condition + batch_effect
       reduced: ~batch_effect
       # Binary valued covariate that shall be used for fold change/effect size

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -28,11 +28,11 @@ diffexp:
       primary_variable: condition
 
 enrichment:
-  gene_sets_file: "resources/gene_sets/dummy.gmt"
   goatools:
     fdr_genes: 0.05
     fdr_go_terms: 0.05
   fgsea:
+    gene_sets_file: "resources/gene_sets/dummy.gmt"
     fdr_gene_set: 0.05
     nperm: 100000
   spia:

--- a/config/samples.tsv
+++ b/config/samples.tsv
@@ -1,3 +1,5 @@
-sample	condition
-A	untreated
-B	treated
+sample	condition	batch_effect
+A	treated	batch1
+B	untreated	batch1
+C	treated	batch2
+D	untreated	batch2

--- a/config/units.tsv
+++ b/config/units.tsv
@@ -1,4 +1,4 @@
 sample	unit	fq1	fq2
-A	lane1	raw/A.1.fq.gz	raw/A.2.fq.gz
-A	lane2	raw/A2.1.fq.gz	raw/A2.2.fq.gz
-B	rep1	raw/B.1.fq.gz	raw/B.2.fq.gz
+A	lane1	raw/a.chr21.1.fq	raw/a.chr21.2.fq
+A	lane2	raw/a.chr21.1.fq	raw/a.chr21.2.fq
+B	rep1	raw/b.chr21.1.fq	raw/b.chr21.2.fq

--- a/config/units.tsv
+++ b/config/units.tsv
@@ -1,4 +1,6 @@
-sample	unit	fq1	fq2
-A	lane1	raw/a.chr21.1.fq	raw/a.chr21.2.fq
-A	lane2	raw/a.chr21.1.fq	raw/a.chr21.2.fq
-B	rep1	raw/b.chr21.1.fq	raw/b.chr21.2.fq
+sample	unit	fragment_len_mean	fragment_len_sd	fq1	fq2
+A	1			raw/a.chr21.1.fq	raw/a.chr21.2.fq
+B	1			raw/b.chr21.1.fq	raw/b.chr21.2.fq
+B	2	300	14	raw/b.chr21.1.fq	
+C	1			raw/a.chr21.1.fq	raw/a.chr21.2.fq
+D	1			raw/b.chr21.1.fq	raw/b.chr21.2.fq

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -4,9 +4,18 @@ include: "rules/quant.smk"
 include: "rules/diffexp.smk"
 include: "rules/enrichment.smk"
 
-def goatools():
-    if is_activated(config["enrichment"]["goatools"]):
-        return  expand(
+
+def all_input(wildcards):
+    """
+    Function defining all requested inputs for the rule all (below).
+    """
+
+    wanted_input = []
+
+    # request goatools if 'activated' in config.yaml
+    if config["enrichment"]["goatools"]["activate"]:
+        wanted_input.extend(
+                expand(
                     [
                         "results/tables/go_terms/{model}.genes-mostsigtrans.diffexp.go_term_enrichment.gene_fdr_{gene_fdr}.go_term_fdr_{go_term_fdr}.tsv",
                         "results/plots/go_terms/{model}.genes-mostsigtrans.diffexp.go_term_enrichment_{go_ns}.gene_fdr_{gene_fdr}.go_term_fdr_{go_term_fdr}.pdf"
@@ -16,53 +25,79 @@ def goatools():
                     gene_fdr=str(config["enrichment"]["goatools"]["fdr_genes"]).replace('.','-'),
                     go_term_fdr=str(config["enrichment"]["goatools"]["fdr_go_terms"]).replace('.','-')
                 )
-    else:
-        return []
+            )
 
+    # request fgsea if 'activated' in config.yaml
+    if config["enrichment"]["fgsea"]["activate"]:
+        wanted_input.extend(
+                expand(
+                    [
+                        "results/tables/fgsea/{model}.all-gene-sets.tsv",
+                        "results/tables/fgsea/{model}.sig-gene-sets.tsv",
+                        "results/plots/fgsea/{model}.table-plot.pdf"
+                    ],
+                    model=config["diffexp"]["models"],
+                    gene_set_fdr=str(config["enrichment"]["fgsea"]["fdr_gene_set"]).replace('.','-'),
+                    nperm=str(config["enrichment"]["fgsea"]["nperm"])
+                )
+            )
+        for model in config["diffexp"]["models"]:
+            wanted_input.extend( get_fgsea_plots(model) )
 
-def fgsea():
-    if is_activated(config["enrichment"]["fgsea"]):
-        return  [ expand(
-                        [
-                            "results/tables/fgsea/{model}.all-gene-sets.tsv",
-                            "results/tables/fgsea/{model}.sig-gene-sets.tsv",
-                            "results/plots/fgsea/{model}.table-plot.pdf"
-                        ],
-                        model=config["diffexp"]["models"],
-                        gene_set_fdr=str(config["enrichment"]["fgsea"]["fdr_gene_set"]).replace('.','-'),
-                        nperm=str(config["enrichment"]["fgsea"]["nperm"])
-                    ),
-                    [get_fgsea_plots(model) for model in config["diffexp"]["models"]]
-                ]
-    else:
-        return []
+    # request spia if 'activated' in config.yaml
+    if config["enrichment"]["spia"]["activate"]:
+        wanted_input.extend(
+                expand(
+                    [ "results/tables/pathways/{model}.pathways.tsv" ],
+                    model=config["diffexp"]["models"],
+                )
+            )
+
+    # workflow output that is always wanted
+
+    # general sleuth output
+    wanted_input.extend(
+            expand(
+                [
+                    "results/tables/diffexp/{model}.transcripts.diffexp.tsv",
+                    "results/plots/diffexp-heatmap/{model}.diffexp-heatmap.pdf",
+                    "results/tables/tpm-matrix/{model}.tpm-matrix.tsv",
+                ],
+                model=config["diffexp"]["models"]
+            )
+        )
+    # sleuth p-value histogram plots
+    wanted_input.extend(
+            expand("results/plots/diffexp/{model}.{level}.diffexp-pval-hist.pdf",
+                model=config["diffexp"]["models"],
+                level=["transcripts", "genes-aggregated", "genes-mostsigtrans" ]
+            )
+        )
+
+    # technical variance vs. observed variance
+    #wanted_input.extend(
+    #        expand("results/plots/variance/{model}.transcripts.plot_vars.pdf", model=config["diffexp"]["models"]),
+    #    )
+
+    # PCA plots of kallisto results, each coloured for a different covariate
+    wanted_input.extend(
+            expand("results/plots/pca/{covariate}.pca.pdf", covariate=samples.columns[samples.columns != "sample"])
+        )
+
+    # sleuth bootstrap plots
+    for model in config["diffexp"]["models"]:
+        wanted_input.extend( get_bootstrap_plots(model) )
+        wanted_input.extend( get_bootstrap_plots(model, config["bootstrap_plots"]["genes_of_interest"]) )
+
+    # fragment length distribution plots
+    wanted_input.extend(
+            expand("results/plots/fld/{unit.sample}-{unit.unit}.fragment-length-dist.pdf",
+                unit=units[["sample", "unit"]].itertuples()
+            )
+        )
+
+    return wanted_input
 
 
 rule all:
-    input:
-        expand(
-            [
-                "results/tables/diffexp/{model}.transcripts.diffexp.tsv",
-                "results/plots/diffexp-heatmap/{model}.diffexp-heatmap.pdf",
-                "results/tables/tpm-matrix/{model}.tpm-matrix.tsv",
-                "results/tables/pathways/{model}.pathways.tsv"
-            ],
-            model=config["diffexp"]["models"]
-        ),
-        # results goatools
-        goatools(),
-        # results fgsea
-        fgsea(),
-        # sleuth p-value histogram plots
-        expand("results/plots/diffexp/{model}.{level}.diffexp-pval-hist.pdf",
-                model=config["diffexp"]["models"],
-                level=["transcripts", "genes-aggregated", "genes-mostsigtrans" ]
-        ),
-        # technical variance vs. observed variance
-#        expand("results/plots/variance/{model}.transcripts.plot_vars.pdf", model=config["diffexp"]["models"]),
-        # PCA plots of kallisto results, each coloured for a different covariate
-        expand("results/plots/pca/{covariate}.pca.pdf", covariate=samples.columns[samples.columns != "sample"]),
-        [get_bootstrap_plots(model) for model in config["diffexp"]["models"]],
-        [get_bootstrap_plots(model, config["bootstrap_plots"]["genes_of_interest"])
-            for model in config["diffexp"]["models"] ],
-        expand("results/plots/fld/{unit.sample}-{unit.unit}.fragment-length-dist.pdf", unit=units[["sample", "unit"]].itertuples())
+    input: all_input

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -4,6 +4,40 @@ include: "rules/quant.smk"
 include: "rules/diffexp.smk"
 include: "rules/enrichment.smk"
 
+def goatools():
+    if is_activated(config["enrichment"]["goatools"]):
+        return  expand(
+                    [
+                        "results/tables/go_terms/{model}.genes-mostsigtrans.diffexp.go_term_enrichment.gene_fdr_{gene_fdr}.go_term_fdr_{go_term_fdr}.tsv",
+                        "results/plots/go_terms/{model}.genes-mostsigtrans.diffexp.go_term_enrichment_{go_ns}.gene_fdr_{gene_fdr}.go_term_fdr_{go_term_fdr}.pdf"
+                    ],
+                    model=config["diffexp"]["models"],
+                    go_ns=["BP", "CC", "MF"],
+                    gene_fdr=str(config["enrichment"]["goatools"]["fdr_genes"]).replace('.','-'),
+                    go_term_fdr=str(config["enrichment"]["goatools"]["fdr_go_terms"]).replace('.','-')
+                )
+    else:
+        return []
+
+
+def fgsea():
+    if is_activated(config["enrichment"]["fgsea"]):
+        return  [ expand(
+                        [
+                            "results/tables/fgsea/{model}.all-gene-sets.tsv",
+                            "results/tables/fgsea/{model}.sig-gene-sets.tsv",
+                            "results/plots/fgsea/{model}.table-plot.pdf"
+                        ],
+                        model=config["diffexp"]["models"],
+                        gene_set_fdr=str(config["enrichment"]["fgsea"]["fdr_gene_set"]).replace('.','-'),
+                        nperm=str(config["enrichment"]["fgsea"]["nperm"])
+                    ),
+                    [get_fgsea_plots(model) for model in config["diffexp"]["models"]]
+                ]
+    else:
+        return []
+
+
 rule all:
     input:
         expand(
@@ -16,28 +50,9 @@ rule all:
             model=config["diffexp"]["models"]
         ),
         # results goatools
-        expand(
-            [
-                "results/tables/go_terms/{model}.genes-mostsigtrans.diffexp.go_term_enrichment.gene_fdr_{gene_fdr}.go_term_fdr_{go_term_fdr}.tsv",
-                "results/plots/go_terms/{model}.genes-mostsigtrans.diffexp.go_term_enrichment_{go_ns}.gene_fdr_{gene_fdr}.go_term_fdr_{go_term_fdr}.pdf"
-            ],
-            model=config["diffexp"]["models"],
-            go_ns=["BP", "CC", "MF"],
-            gene_fdr=str(config["enrichment"]["goatools"]["fdr_genes"]).replace('.','-'),
-            go_term_fdr=str(config["enrichment"]["goatools"]["fdr_go_terms"]).replace('.','-')
-        ),
+        goatools(),
         # results fgsea
-        expand(
-            [
-                "results/tables/fgsea/{model}.all-gene-sets.tsv",
-                "results/tables/fgsea/{model}.sig-gene-sets.tsv",
-                "results/plots/fgsea/{model}.table-plot.pdf"
-            ],
-            model=config["diffexp"]["models"],
-            gene_set_fdr=str(config["enrichment"]["fgsea"]["fdr_gene_set"]).replace('.','-'),
-            nperm=str(config["enrichment"]["fgsea"]["nperm"])
-        ),
-        [get_fgsea_plots(model) for model in config["diffexp"]["models"]],
+        fgsea(),
         # sleuth p-value histogram plots
         expand("results/plots/diffexp/{model}.{level}.diffexp-pval-hist.pdf",
                 model=config["diffexp"]["models"],

--- a/workflow/envs/goatools.yaml
+++ b/workflow/envs/goatools.yaml
@@ -8,4 +8,5 @@ dependencies:
   - python =3.7
   - pandas =0.25
   - matplotlib =3.1
+  - pillow =6.2
 

--- a/workflow/envs/sleuth.yaml
+++ b/workflow/envs/sleuth.yaml
@@ -3,11 +3,10 @@ channels:
   - bioconda
 dependencies:
   - r-sleuth =0.30
-  - bioconductor-rhdf5lib =1.4.3
-  - bioconductor-rhdf5 =2.26.2
-  - bioconductor-biomart =2.36.1
+  - bioconductor-rhdf5lib =1.6.0
+  - bioconductor-rhdf5 =2.28.0
+  - bioconductor-biomart =2.40.3
   - r-gridextra =2.3
   - r-pheatmap =1.0.12
   - r-tidyverse =1.2.1
-  - r-base =3.5.1=h271c98b_1006 # see https://github.com/conda-forge/r-base-feedstock/issues/100
-                                # TODO replace with r-base =3.6 once bioconda r-rebuilt is done.
+  - r-base =3.6

--- a/workflow/envs/spia.yaml
+++ b/workflow/envs/spia.yaml
@@ -2,21 +2,21 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - r-base =3.5
-  - bioconductor-spia =2.34
-  - bioconductor-graphite =1.28
-  - bioconductor-org.mm.eg.db =3.7
-  - bioconductor-org.hs.eg.db =3.7
-  - bioconductor-org.at.tair.db =3.7
-  - bioconductor-org.bt.eg.db =3.7
-  - bioconductor-org.ce.eg.db =3.7
-  - bioconductor-org.dm.eg.db =3.7
-  - bioconductor-org.dr.eg.db =3.7
-  - bioconductor-org.eck12.eg.db =3.7
-  - bioconductor-org.gg.eg.db =3.7
-  - bioconductor-org.hs.eg.db =3.7
-  - bioconductor-org.rn.eg.db =3.7
-  - bioconductor-org.sc.sgd.db =3.7
-  - bioconductor-org.ss.eg.db =3.7
-  - bioconductor-org.xl.eg.db =3.7
+  - r-base =3.6
+  - bioconductor-spia =2.36
+  - bioconductor-graphite =1.30
+  - bioconductor-org.mm.eg.db =3.8.2
+  - bioconductor-org.hs.eg.db =3.8.2
+  - bioconductor-org.at.tair.db =3.8.2
+  - bioconductor-org.bt.eg.db =3.8.2
+  - bioconductor-org.ce.eg.db =3.8.2
+  - bioconductor-org.dm.eg.db =3.8.2
+  - bioconductor-org.dr.eg.db =3.8.2
+  - bioconductor-org.eck12.eg.db =3.8.2
+  - bioconductor-org.gg.eg.db =3.8.2
+  - bioconductor-org.hs.eg.db =3.8.2
+  - bioconductor-org.rn.eg.db =3.8.2
+  - bioconductor-org.sc.sgd.db =3.8.2
+  - bioconductor-org.ss.eg.db =3.8.2
+  - bioconductor-org.xl.eg.db =3.8.2
   - r-tidyverse =1.2

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -54,51 +54,46 @@ def get_trimmed(wildcards):
     return expand("results/trimmed/{sample}-{unit}.fastq.gz", **wildcards)
 
 def is_activated(config_element):
-    return config_element.get('activated', 'false') in {"true","True"}
-  
+    return config_element['activate'] in {"true","True"}
+
 def get_bootstrap_plots(model, gene_list=None):
     """Dynamically determine which transcripts to plot based on
        checkpoint output."""
-    def inner(wildcards):
-        transcripts = dict()
-        genes = set()
-        # Obtain results from the sleuth_diffexp checkpoint.
-        # This happens dynamically after the checkpoint is completed, and
-        # is skipped automatically before completion.
-        results = pd.read_csv(
-            checkpoints.sleuth_diffexp.get(model=model).output.transcripts, sep="\t").dropna()
-        # group transcripts by gene
-        if gene_list is None:
-            results = results[results.qval <= config["bootstrap_plots"]["FDR"]][:config["bootstrap_plots"]["top_n"]] 
-            genes = set(results.ext_gene)
-        else:
-            genes = set(gene_list)
-            genes.add("Custom")
-        for g in genes:
-            if not pd.isnull(g):
-                valid = results.ext_gene == g
-                trx = set(results[valid].target_id)
-                transcripts[g] = trx
-        # Require the respective output from the plot_bootstrap rule.
-        return ["results/plots/bootstrap/{gene}/{gene}.{transcript}.{model}.bootstrap.pdf".format(gene=g, transcript=t, model=model)
-                for g, ts in transcripts.items()
-                for t in ts]
-    return inner
+    transcripts = dict()
+    genes = set()
+    # Obtain results from the sleuth_diffexp checkpoint.
+    # This happens dynamically after the checkpoint is completed, and
+    # is skipped automatically before completion.
+    results = pd.read_csv(
+        checkpoints.sleuth_diffexp.get(model=model).output.transcripts, sep="\t").dropna()
+    # group transcripts by gene
+    if gene_list is None:
+        results = results[results.qval <= config["bootstrap_plots"]["FDR"]][:config["bootstrap_plots"]["top_n"]]
+        genes = set(results.ext_gene)
+    else:
+        genes = set(gene_list)
+        genes.add("Custom")
+    for g in genes:
+        if not pd.isnull(g):
+            valid = results.ext_gene == g
+            trx = set(results[valid].target_id)
+            transcripts[g] = trx
+    # Require the respective output from the plot_bootstrap rule.
+    return ["results/plots/bootstrap/{gene}/{gene}.{transcript}.{model}.bootstrap.pdf".format(gene=g, transcript=t, model=model)
+            for g, ts in transcripts.items()
+            for t in ts]
 
 def get_fgsea_plots(model):
-    def inner(wildcards):
-        plots = set()
-        table = pd.read_csv(
-                    checkpoints.fgsea.get( model=model ).output.significant,
-                    sep="\t").dropna()
-        gs = set(table['pathway'])
-        for gene_set in gs:
-            plots.add(
-                "results/plots/fgsea/{model}.{gene_set}.gene-set-plot.pdf".format(
-                    model=model,
-                    gene_set=gene_set
-                    )
+    plots = set()
+    table = pd.read_csv(
+                checkpoints.fgsea.get( model=model ).output.significant,
+                sep="\t").dropna()
+    gs = set(table['pathway'])
+    for gene_set in gs:
+        plots.add(
+            "results/plots/fgsea/{model}.{gene_set}.gene-set-plot.pdf".format(
+                model=model,
+                gene_set=gene_set
                 )
-        return plots
-    return inner
-
+            )
+    return plots

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -53,6 +53,9 @@ def get_trimmed(wildcards):
     # single end sample
     return expand("results/trimmed/{sample}-{unit}.fastq.gz", **wildcards)
 
+def is_activated(config_element):
+    return config_element.get('activated', 'false') in {"true","True"}
+  
 def get_bootstrap_plots(model, gene_list=None):
     """Dynamically determine which transcripts to plot based on
        checkpoint output."""

--- a/workflow/rules/diffexp.smk
+++ b/workflow/rules/diffexp.smk
@@ -40,6 +40,7 @@ rule sleuth_init:
     log:
         "logs/sleuth/{model}.init.log"
     group: "sleuth-init"
+    threads: 6
     script:
         "../scripts/sleuth-init.R"
 
@@ -168,4 +169,3 @@ rule plot_vars:
         "logs/plots/variance/{model}.plot_vars.log"
     script:
         "../scripts/plot-variances.R"
-

--- a/workflow/rules/enrichment.smk
+++ b/workflow/rules/enrichment.smk
@@ -22,7 +22,7 @@ checkpoint fgsea:
     input:
         samples="results/sleuth/samples.tsv",
         diffexp="results/tables/diffexp/{model}.genes-mostsigtrans.diffexp.tsv",
-        gene_sets=config["enrichment"]["gene_sets_file"]
+        gene_sets=config["enrichment"]["fgsea"]["gene_sets_file"]
     output:
         enrichment=report(
             "results/tables/fgsea/{model}.all-gene-sets.tsv",
@@ -62,7 +62,7 @@ rule fgsea_plot_gene_set:
     input:
         samples="results/sleuth/samples.tsv",
         diffexp="results/tables/diffexp/{model}.genes-mostsigtrans.diffexp.tsv",
-        gene_sets=config["enrichment"]["gene_sets_file"],
+        gene_sets=config["enrichment"]["fgsea"]["gene_sets_file"],
         sig_gene_sets="results/tables/fgsea/{model}.sig-gene-sets.tsv"
     output:
         report(

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -56,6 +56,8 @@ properties:
       goatools:
         type: object
         properties:
+          activate:
+            type: boolean
           fdr_genes:
             type: number
           fdr_go_terms:
@@ -66,6 +68,8 @@ properties:
       fgsea:
         type: object
         properties:
+          activate:
+            type: boolean
           gene_sets_file:
             type: string
           fdr_gene_set:
@@ -79,6 +83,8 @@ properties:
       spia:
         type: object
         properties:
+          activate:
+            type: boolean
           pathway_database:
             type: string
         required:

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -53,8 +53,6 @@ properties:
   enrichment:
     type: object
     properties:
-      gene_sets_file:
-        type: string
       goatools:
         type: object
         properties:
@@ -68,11 +66,14 @@ properties:
       fgsea:
         type: object
         properties:
+          gene_sets_file:
+            type: string
           fdr_gene_set:
             type: number
           nperm:
             type: integer
         required:
+          - gene_sets_file
           - fdr_gene_set
           - nperm
       spia:
@@ -82,8 +83,6 @@ properties:
             type: string
         required:
           - pathway_database
-    required:
-      - gene_sets_file
 
 
   bootstrap_plots:

--- a/workflow/scripts/sleuth-init.R
+++ b/workflow/scripts/sleuth-init.R
@@ -54,7 +54,8 @@ so <- sleuth_prep(  samples,
                     target_mapping = t2g,
                     aggregation_column = "ens_gene",
                     read_bootstrap_tpm = TRUE,
-                    transform_fun_counts = function(x) log2(x + 0.5)
+                    transform_fun_counts = function(x) log2(x + 0.5),
+                    num_cores = snakemake@threads
                     )
 
 custom_transcripts <- so$obs_raw %>%


### PR DESCRIPTION
* `r-base = 3.6` in all environments
* introduce `activate: false` defaults for spia, fgsea and goatools (set to `true` to run the tools)
* restrict thread usage of `sleuth_prep()` in rule `sleuth_init` to whatever the pipeline provides (with a current default max at `6`), instead of letting it take whatever it can find -- this can lead to high RAM usage and running R code in the form of scripts seems to have a hard limit at 40 GB RAM