### PR TITLE
any name for diffexp grouping column, fix no custom_transcripts, future-proof column select()

### DIFF
--- a/workflow/schemas/samples.schema.yaml
+++ b/workflow/schemas/samples.schema.yaml
@@ -11,4 +11,3 @@ properties:
 
 required:
   - sample
-  - condition


### PR DESCRIPTION
The main point of this PR is to remove the schema-requirement of a sample.tsv sheet column named `condition`. Usually, it makes more sense to specify a more informative name for that column (e.g. something like `group1_vs_group2`), which will also be picked up in labeling etc. This also requires removing the `condition` column from the respective `select()`, but the custom-named column will be picked up through the formula, anyways.

As a side-effect, this PR future-proofs the column `select()` on a vector of strings with the `all_of()` function and fixes a bug that occurs, if the provided transcriptome does NOT contain any custom transcripts -- i.e. we now handle this case properly.