### PR TITLE
pin all uses of select() to a library, avoid AnnotationDbi vs. dplyr collisions

### DIFF
--- a/workflow/scripts/fgsea.R
+++ b/workflow/scripts/fgsea.R
@@ -67,8 +67,8 @@ if ( (fgsea_res %>% count() %>% pull(n)) == 0 ) {
                         leading_edge_entrez_id = str_c(leading_edge_entrez_id, collapse = ','),
                         leading_edge_ens_gene = str_c(leading_edge_ens_gene, collapse = ',')
                     ) %>%
-                    inner_join(fgsea_res %>% select(-leadingEdge), by = "pathway") %>%
-                    select(-leadingEdge, -leading_edge_symbol,
+                    inner_join(fgsea_res %>% dplyr::select(-leadingEdge), by = "pathway") %>%
+                    dplyr::select(-leadingEdge, -leading_edge_symbol,
                            -leading_edge_entrez_id, -leading_edge_ens_gene,
                             leading_edge_symbol, leading_edge_ens_gene,
                             leading_edge_entrez_id, leadingEdge)

--- a/workflow/scripts/sleuth-diffexp.R
+++ b/workflow/scripts/sleuth-diffexp.R
@@ -34,7 +34,7 @@ write_results <- function(mode, output, output_all) {
 	      beta_col_name <- str_c("b", covariate, sep = "_")
             beta_se_col_name <- str_c(beta_col_name, "se", sep = "_")
             all_wald <- sleuth_results(so, covariate, "wt", show_all = TRUE, pval_aggregate = FALSE) %>%
-                        select( target_id = target_id,
+                        dplyr::select( target_id = target_id,
                                 !!beta_col_name := b,
                                 !!beta_se_col_name := se_b)
             signed_pi_col_name <- str_c("signed_pi_value", covariate, sep = "_")

--- a/workflow/scripts/sleuth-init.R
+++ b/workflow/scripts/sleuth-init.R
@@ -45,7 +45,7 @@ if(!is.null(model)) {
     # select the columns required by sleuth and filter to all samples where
     # none of the given variables are NA
     samples <- samples %>%
-                select(sample, path, all_of(variables)) %>%
+                dplyr::select(sample, path, all_of(variables)) %>%
                 drop_na()
 }
 


### PR DESCRIPTION
Make the use of select explicit with `dplyr::select()` vs. `AnnotationDbi::select()`. This avoids problems if one or the other package is loaded first, or if the second of the packages is added to an environment in future script changes.