### PR TITLE
Miscellaneous fixes

### DIFF
--- a/workflow/report/fgsea-collapsed-table-plot.rst
+++ b/workflow/report/fgsea-collapsed-table-plot.rst
@@ -1,0 +1,2 @@
+**Gene set enrichment table plot** of all gene sets tested by fgsea. The most significant transcript of each gene was determined by sleuth using the model ``{{ snakemake.params.model["full"] }}``.
+

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -25,6 +25,7 @@ def drop_unique_cols(df):
     singular_cols = df.nunique().loc[(df.nunique().values <= 1)].index
     return df.drop(singular_cols, axis=1)
 
+
 samples = drop_unique_cols(samples)
 validate(samples, schema="../schemas/samples.schema.yaml")
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -22,10 +22,10 @@ samples.index.names = ["sample_id"]
 
 
 def drop_unique_cols(df):
-    return df.drop(df.nunique().loc[(df.nunique().values <= 1)].index, axis=1)
+    singular_cols = df.nunique().loc[(df.nunique().values <= 1)].index
+    return df.drop(singular_cols, axis=1)
 
 samples = drop_unique_cols(samples)
-print(samples)
 validate(samples, schema="../schemas/samples.schema.yaml")
 
 units = pd.read_csv(config["units"], dtype=str, sep="\t", comment="#").set_index(

--- a/workflow/rules/enrichment.smk
+++ b/workflow/rules/enrichment.smk
@@ -73,6 +73,11 @@ rule fgsea:
             caption="../report/fgsea-table-plot.rst",
             category="Gene set enrichment analysis",
         ),
+        plot_collapsed=report(
+            "results/plots/fgsea/{model}.collapsed_pathways.table-plot.pdf",
+            caption="../report/fgsea-collapsed-table-plot.rst",
+            category="Gene set enrichment analysis",
+        ),
     params:
         bioc_pkg=get_bioc_species_pkg,
         model=get_model,

--- a/workflow/scripts/plot-diffexp-heatmap.R
+++ b/workflow/scripts/plot-diffexp-heatmap.R
@@ -10,8 +10,5 @@ diffexp <- read.table(snakemake@input[["diffexp"]], sep = "\t", header = TRUE)
 
 pdf(file = snakemake@output[[1]], width = 14)
 
-plot_transcript_heatmap(so, transcripts = diffexp$target_id[1:20], main="Top 20 differentially expressed transcripts (TPM)")
-
-# TODO, once pachterlab/sleuth#214 is merged, add this to get gene names
-# , labels_row = diffexp$ext_gene[1:20])
+plot_transcript_heatmap(so, transcripts = diffexp$target_id[1:20], main="Top 20 differentially expressed transcripts (TPM)", labels_row = diffexp$ext_gene[1:20])
 dev.off()

--- a/workflow/scripts/plot-pca.R
+++ b/workflow/scripts/plot-pca.R
@@ -5,8 +5,6 @@ sink(log, type="message")
 library("sleuth")
 library("ggpubr")
 
-so <- sleuth_load(snakemake@input[[1]])
-
 #principal components
 pc <- 4
 


### PR DESCRIPTION
This PR aims to fix some issues I encountered when using the pipeline:
  - The logic in `rules/common.smk::is_single_end` was somewhat backwards
  - fgsea:
    - fgsea has an option to collapse enriched pathways, such that they become independent; this now also gets plotted
    - fgsea now only plots (at most) 1000 significant (w.r.t. fdr) pathways
    - pathways may have weird names, so resulting filenames might not be valid, i.e. saving to file failed in some cases; to fix that, replace unwanted characters with underscore
  - the diffexp-heatmap plot now uses gene names instead of transcript names (as suggested in the TODO)
  - do not load sleuth object twice in `plot-pca.R`
  - spia: if there are no significant genes, make an empty plot instead of failing
  - common.smk: 
    - allow `#` comments in samples.tsv + units.tsv
    - remove singular columns from samples dataframe (since every column is used in the analysis scripts at some point, and singular ones just make everything fail)