### PR TITLE
chore: Bump r-base and related package versions to R 4.1

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -13,7 +13,7 @@ resources:
     # you want -- this needs to be compatible with the versions `r-base` and the
     # bioconductor packages specified e.g. in `envs/` files `fgsea.yaml`, `spia.yaml` and
     # `ens_gene_to_go.yaml`
-    species_db_version: "3.12"
+    species_db_version: "3.13"
   ontology:
     # gene ontology to download, used e.g. in goatools
     gene_ontology: "http://current.geneontology.org/ontology/go-basic.obo"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -13,7 +13,7 @@ resources:
     # you want -- this needs to be compatible with the versions `r-base` and the
     # bioconductor packages specified e.g. in `envs/` files `fgsea.yaml`, `spia.yaml` and
     # `ens_gene_to_go.yaml`
-    species_db_version: "3.12"
+    species_db_version: "3.13"
   ontology:
     # gene ontology to download, used e.g. in goatools
     gene_ontology: "http://current.geneontology.org/ontology/go-basic.obo"

--- a/workflow/envs/ens_gene_to_go.yaml
+++ b/workflow/envs/ens_gene_to_go.yaml
@@ -3,5 +3,5 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - r-base=4.0
+  - r-base=4.1
   - r-tidyverse=1.3

--- a/workflow/envs/fgsea.yaml
+++ b/workflow/envs/fgsea.yaml
@@ -2,6 +2,6 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - r-base =4.0
+  - r-base =4.1
   - r-tidyverse =1.3
-  - bioconductor-fgsea =1.16
+  - bioconductor-fgsea =1.18

--- a/workflow/envs/ihw.yaml
+++ b/workflow/envs/ihw.yaml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - r-base =4.0
-  - bioconductor-ihw =1.18.0
+  - r-base =4.1
+  - bioconductor-ihw =1.20.0
   - r-tidyverse =1.3
   - r-ggpubr =0.4

--- a/workflow/envs/spia.yaml
+++ b/workflow/envs/spia.yaml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - r-base =4.0
-  - bioconductor-spia =2.42
-  - bioconductor-graphite =1.36
+  - r-base =4.1
+  - bioconductor-spia =2.44
+  - bioconductor-graphite =1.38
   - r-tidyverse =1.3

--- a/workflow/scripts/vega_plot_volcano.py
+++ b/workflow/scripts/vega_plot_volcano.py
@@ -42,7 +42,8 @@ def main(snakemake):
         for c in list(df.columns)
         if c.startswith(f"b_{primary_var}") and not c.endswith("_se")
     ]
-    assert len(primary_cols) == 1
+    if len(primary_cols) > 1:
+        print("WARNING: found {len(primary_cols)} possible primary variables")
     beta_col = primary_cols[0]
 
     # only keep columns needed for plot


### PR DESCRIPTION
In some combinations of package versions, especially with respect to the `species_db_version` entry in config.yaml, version incompatibilites could occur. By bumping versions to depend on r-base =4.1, this should not happen anymore.