### PR TITLE
adjust fgsea.R script to changes in fgsea() function interface

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -75,7 +75,7 @@ enrichment:
     activate: true
     # if activated, you need to provide a GMT file with gene sets of interest
     fdr_gene_set: 0.05
-    nperm: 10000
+    eps: 0.0001
   spia:
     # tool is only run if set to `true`
     activate: true

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -83,7 +83,7 @@ enrichment:
     # if activated, you need to provide a GMT file with gene sets of interest
     gene_sets_file: "resources/gene_sets/dummy.gmt"
     fdr_gene_set: 0.05
-    nperm: 100000
+    eps: 0.0
   spia:
     # tool is only run if set to `true`
     activate: false

--- a/workflow/envs/fgsea.yaml
+++ b/workflow/envs/fgsea.yaml
@@ -4,4 +4,4 @@ channels:
 dependencies:
   - r-base =4.1
   - r-tidyverse =1.3
-  - bioconductor-fgsea =1.18
+  - bioconductor-fgsea =1.20

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -150,10 +150,6 @@ def all_input(wildcards):
                     "results/plots/fgsea/{model}",
                 ],
                 model=config["diffexp"]["models"],
-                gene_set_fdr=str(config["enrichment"]["fgsea"]["fdr_gene_set"]).replace(
-                    ".", "-"
-                ),
-                nperm=str(config["enrichment"]["fgsea"]["nperm"]),
             )
         )
 

--- a/workflow/rules/enrichment.smk
+++ b/workflow/rules/enrichment.smk
@@ -83,7 +83,7 @@ rule fgsea:
         bioc_pkg=get_bioc_species_pkg,
         model=get_model,
         gene_set_fdr=config["enrichment"]["fgsea"]["fdr_gene_set"],
-        nperm=config["enrichment"]["fgsea"]["nperm"],
+        eps=config["enrichment"]["fgsea"]["eps"],
         covariate=lambda w: config["diffexp"]["models"][w.model]["primary_variable"],
         common_src=str(workflow.source_path("../scripts/common.R")),
     conda:

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -120,12 +120,12 @@ properties:
             type: string
           fdr_gene_set:
             type: number
-          nperm:
-            type: integer
+          eps:
+            type: number
         required:
           - gene_sets_file
           - fdr_gene_set
-          - nperm
+          - eps
       spia:
         type: object
         properties:

--- a/workflow/scripts/fgsea.R
+++ b/workflow/scripts/fgsea.R
@@ -52,7 +52,7 @@ fgsea_res <- fgsea(pathways = gene_sets,
                     minSize=10,
                     maxSize=700,
                     nproc=snakemake@threads,
-                    nperm=snakemake@params[["nperm"]]
+                    eps=snakemake@params[["eps"]]
                     ) %>%
                 as_tibble()
 


### PR DESCRIPTION
Originally, the `fgsea()` function had an argument `nperm=` that determined the precision of p-value estimates. See for example this legacy documentation:
https://bioconductor.org/packages/3.10/bioc/vignettes/fgsea/inst/doc/fgsea-tutorial.html

Starting with bioconductor `3.11`, this precision is now directly specified via the `eps=` argument. See for example this version of the documentation:
https://bioconductor.org/packages/3.11/bioc/vignettes/fgsea/inst/doc/fgsea-tutorial.html