### PR TITLE
fix: update samtools.yaml to latest `1.17` and update github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Formatting
-      uses: github/super-linter@v4
+      uses: github/super-linter@v5
       env:
         VALIDATE_ALL_CODEBASE: false
         DEFAULT_BRANCH: main
@@ -54,7 +54,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Linting
-      uses: snakemake/snakemake-github-action@v1.22.0
+      uses: snakemake/snakemake-github-action@v1
       with:
         directory: .test
         snakefile: workflow/Snakefile
@@ -73,7 +73,7 @@ jobs:
         submodules: recursive
 
     - name: Test workflow
-      uses: snakemake/snakemake-github-action@v1.23.0
+      uses: snakemake/snakemake-github-action@v1
       with:
         directory: .test
         snakefile: workflow/Snakefile
@@ -92,7 +92,7 @@ jobs:
         submodules: recursive
 
     - name: Test 3-prime-workflow
-      uses: snakemake/snakemake-github-action@v1.23.0
+      uses: snakemake/snakemake-github-action@v1
       with:
         directory: .test/3-prime-config
         snakefile: workflow/Snakefile
@@ -101,7 +101,7 @@ jobs:
     # TODO: add some kind of test mode to report generation which does not really try to include
     # results.
     # - name: Test report
-    #   uses: snakemake/snakemake-github-action@v1.22.0
+    #   uses: snakemake/snakemake-github-action@v1
     #   with:
     #     directory: .test
     #     snakefile: workflow/Snakefile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Formatting
       uses: github/super-linter@v5
       env:
@@ -52,7 +52,7 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Linting
       uses: snakemake/snakemake-github-action@v1
       with:
@@ -68,7 +68,7 @@ jobs:
     steps:
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 
@@ -87,7 +87,7 @@ jobs:
     steps:
     
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 

--- a/workflow/envs/samtools.yaml
+++ b/workflow/envs/samtools.yaml
@@ -4,4 +4,4 @@ channels:
   - nodefaults
 
 dependencies:
-  - samtools =1.9
+  - samtools =1.17


### PR DESCRIPTION
@manuelphilip Was there a reason for the old version of `samtools =1.9`? Otherwise I would update this to the latest version.

I found this, because we were seeing very large memory usage (`> 20GB`) for the `rule get_mapped_canonical_transcripts`, which should stream through the BAM (and the BAMs we had were below `1GB`), so I wouldn't expect any large memory usage. The only explanation I have so far, is that maybe this very old version of samtools somehow had a bug or very suboptimal handling of BAM files.