### PR TITLE
chore: update bioconductor-biomart to 2.58

### DIFF
--- a/workflow/envs/biomart.yaml
+++ b/workflow/envs/biomart.yaml
@@ -2,9 +2,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconductor-biomart =2.56
+  - bioconductor-biomart =2.58
   - r-tidyverse =2.0
-  # remove once we can update to bioconductor-biomart of the 3.18 release, which will
-  # include this proper fix for the underlying compatibility issue:
-  # https://github.com/Bioconductor/BiocFileCache/pull/50
-  - r-dbplyr=2.3.4


### PR DESCRIPTION
also remove the dbplyr version pinning patch that should not be necessary any more