### PR TITLE
feat: Allow bam input files

### DIFF
--- a/workflow/rules/bam.smk
+++ b/workflow/rules/bam.smk
@@ -1,0 +1,28 @@
+rule separate_bam_paired:
+  input:
+    "{bam_file}.bam"
+  output:
+    "{bam_file}.1.fq",
+    "{bam_file}.2.fq",
+  log:
+    "{bam_file}.separate.log",
+  params:
+    fastq="-n",
+  threads: 3
+  wrapper:
+      "v3.10.2/bio/samtools/fastq/separate"
+
+
+rule samtools_fastq_interleaved:
+  input:
+    "{bam_file}.bam",
+  output:
+    "{bam_file}.fq",
+  log:
+    "{bam_file}.interleaved.log",
+  params:
+    " ",
+  threads: 3
+  wrapper:
+    "v3.10.2/bio/samtools/fastq/interleaved"
+    

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -98,7 +98,14 @@ def is_single_end(sample, unit):
 
 def get_fastqs(wildcards):
     """Get raw FASTQ files from unit sheet."""
-    if is_single_end(wildcards.sample, wildcards.unit):
+    if not pd.isnull(units.loc[(sample, unit), "bam_single"]):
+        fqfrombam = units.loc[(wildcards.sample, wildcards.unit), "bam_single"].replace(".bam",".fq")
+        return fqfrombam
+    elif not pd.isnull(units.loc[(sample, unit), "bam_paired"]):
+        fqfrombam1 = units.loc[(wildcards.sample, wildcards.unit), "bam_paired"].replace(".bam",".1.fq")
+        fqfrombam2 = units.loc[(wildcards.sample, wildcards.unit), "bam_paired"].replace(".bam",".3.fq")
+        return [fqfrombam1, fqfrombam2]
+    elif is_single_end(wildcards.sample, wildcards.unit):
         return units.loc[(wildcards.sample, wildcards.unit), "fq1"]
     else:
         u = units.loc[(wildcards.sample, wildcards.unit), ["fq1", "fq2"]].dropna()


### PR DESCRIPTION
This PR allows bam files as input via the fields `bam_single` or `bam_paired` in `units.tsv`.