### PR TITLE
fix: Handle missing bam columns in units.tsv

### DIFF
--- a/.test/config/units.tsv
+++ b/.test/config/units.tsv
@@ -1,4 +1,4 @@
-sample	unit	fragment_len_mean	fragment_len_sd	fq1	fq2	bam_single	bam_paired
+sample	unit	fragment_len_mean	fragment_len_sd	fq1	fq2
 A	1			ngs-test-data/reads/a.chr21.1.fq	ngs-test-data/reads/a.chr21.2.fq
 B	1			ngs-test-data/reads/b.chr21.1.fq	ngs-test-data/reads/b.chr21.2.fq
 B	2	300	14	ngs-test-data/reads/b.chr21.1.fq	

--- a/workflow/rules/bam.smk
+++ b/workflow/rules/bam.smk
@@ -4,6 +4,7 @@ rule bam_paired_to_fastq:
             query="sample == '{sample}' & unit == '{unit}'",
             within=units,
             cols="bam_paired",
+            default=None,
         ),
     output:
         "results/fastq/{sample}-{unit}.1.fq.gz",
@@ -23,6 +24,7 @@ rule bam_single_to_fastq:
             query="sample == '{sample}' & unit == '{unit}'",
             within=units,
             cols="bam_single",
+            default=None,
         ),
     output:
         "results/fastq/{sample}-{unit}.fq.gz",

--- a/workflow/rules/bam.smk
+++ b/workflow/rules/bam.smk
@@ -4,7 +4,6 @@ rule bam_paired_to_fastq:
             query="sample == '{sample}' & unit == '{unit}'",
             within=units,
             cols="bam_paired",
-            default=None,
         ),
     output:
         "results/fastq/{sample}-{unit}.1.fq.gz",
@@ -24,7 +23,6 @@ rule bam_single_to_fastq:
             query="sample == '{sample}' & unit == '{unit}'",
             within=units,
             cols="bam_single",
-            default=None,
         ),
     output:
         "results/fastq/{sample}-{unit}.fq.gz",

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -88,7 +88,7 @@ def get_model(wildcards):
 
 def is_single_end(sample, unit):
     """Determine whether unit is single-end."""
-    if 'bam_paired' in units.columns:
+    if "bam_paired" in units.columns:
         bam_paired_not_present = pd.isnull(units.loc[(sample, unit), "bam_paired"])
     else:
         bam_paired_not_present = True
@@ -99,9 +99,13 @@ def is_single_end(sample, unit):
 
 def get_fastqs(wildcards):
     """Get raw FASTQ files from unit sheet."""
-    if 'bam_single' in units.columns and not pd.isnull(units.loc[(wildcards.sample, wildcards.unit), "bam_single"]):
+    if "bam_single" in units.columns and not pd.isnull(
+        units.loc[(wildcards.sample, wildcards.unit), "bam_single"]
+    ):
         return f"results/fastq/{wildcards.sample}-{wildcards.unit}.fq.gz"
-    elif 'bam_paired' in units.columns and not pd.isnull(units.loc[(wildcards.sample, wildcards.unit), "bam_paired"]):
+    elif "bam_paired" in units.columns and not pd.isnull(
+        units.loc[(wildcards.sample, wildcards.unit), "bam_paired"]
+    ):
         fqfrombam1 = f"results/fastq/{wildcards.sample}-{wildcards.unit}.1.fq.gz"
         fqfrombam2 = f"results/fastq/{wildcards.sample}-{wildcards.unit}.2.fq.gz"
         return [fqfrombam1, fqfrombam2]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -102,9 +102,13 @@ def is_single_end(sample, unit):
 
 def get_fastqs(wildcards):
     """Get raw FASTQ files from unit sheet."""
-    if not column_missing_or_empty("bam_single", units, wildcards.sample, wildcards.unit):
+    if not column_missing_or_empty(
+        "bam_single", units, wildcards.sample, wildcards.unit
+    ):
         return f"results/fastq/{wildcards.sample}-{wildcards.unit}.fq.gz"
-    elif not column_missing_or_empty("bam_paired", units, wildcards.sample, wildcards.unit):
+    elif not column_missing_or_empty(
+        "bam_paired", units, wildcards.sample, wildcards.unit
+    ):
         return expand(
             "results/fastq/{sample}-{unit}.{read}.fq.gz",
             sample=wildcards.sample,

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -85,6 +85,7 @@ def get_model(wildcards):
         return {"full": None}
     return config["diffexp"]["models"][wildcards.model]
 
+
 def column_missing_or_empty(column_name, dataframe, sample, unit):
     if column_name in dataframe.columns:
         return pd.isnull(dataframe.loc[(sample, unit), column_name])
@@ -94,7 +95,9 @@ def column_missing_or_empty(column_name, dataframe, sample, unit):
 
 def is_single_end(sample, unit):
     """Determine whether unit is single-end."""
-    return column_missing_or_empty("fq2", units, sample, unit) and column_missing_or_empty("bam_paired", units, sample, unit)
+    return column_missing_or_empty(
+        "fq2", units, sample, unit
+    ) and column_missing_or_empty("bam_paired", units, sample, unit)
 
 
 def get_fastqs(wildcards):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -105,10 +105,11 @@ def get_fastqs(wildcards):
     elif "bam_paired" in units.columns and not pd.isnull(
         units.loc[(wildcards.sample, wildcards.unit), "bam_paired"]
     ):
-        return expand("results/fastq/{sample}-{unit}.{read}.fq.gz",
-            sample = wildcards.sample,
-            unit = wildcards.unit,
-            read = ["1", "2"],
+        return expand(
+            "results/fastq/{sample}-{unit}.{read}.fq.gz",
+            sample=wildcards.sample,
+            unit=wildcards.unit,
+            read=["1", "2"],
         )
     elif is_single_end(wildcards.sample, wildcards.unit):
         return units.loc[(wildcards.sample, wildcards.unit), "fq1"]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -105,9 +105,11 @@ def get_fastqs(wildcards):
     elif "bam_paired" in units.columns and not pd.isnull(
         units.loc[(wildcards.sample, wildcards.unit), "bam_paired"]
     ):
-        fqfrombam1 = f"results/fastq/{wildcards.sample}-{wildcards.unit}.1.fq.gz"
-        fqfrombam2 = f"results/fastq/{wildcards.sample}-{wildcards.unit}.2.fq.gz"
-        return [fqfrombam1, fqfrombam2]
+        return expand("results/fastq/{sample}-{unit}.{read}.fq.gz",
+            sample = wildcards.sample,
+            unit = wildcards.unit,
+            read = ["1", "2"],
+        )
     elif is_single_end(wildcards.sample, wildcards.unit):
         return units.loc[(wildcards.sample, wildcards.unit), "fq1"]
     else:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -100,9 +100,7 @@ def get_fastqs(wildcards):
     """Get raw FASTQ files from unit sheet."""
     if column_missing_or_empty("bam_single", units, wildcards.sample, wildcards.unit):
         return f"results/fastq/{wildcards.sample}-{wildcards.unit}.fq.gz"
-    elif "bam_paired" in units.columns and not pd.isnull(
-        units.loc[(wildcards.sample, wildcards.unit), "bam_paired"]
-    ):
+    elif column_missing_or_empty("bam_paired", units, wildcards.sample, wildcards.unit):
         return expand(
             "results/fastq/{sample}-{unit}.{read}.fq.gz",
             sample=wildcards.sample,

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -102,9 +102,9 @@ def is_single_end(sample, unit):
 
 def get_fastqs(wildcards):
     """Get raw FASTQ files from unit sheet."""
-    if column_missing_or_empty("bam_single", units, wildcards.sample, wildcards.unit):
+    if not column_missing_or_empty("bam_single", units, wildcards.sample, wildcards.unit):
         return f"results/fastq/{wildcards.sample}-{wildcards.unit}.fq.gz"
-    elif column_missing_or_empty("bam_paired", units, wildcards.sample, wildcards.unit):
+    elif not column_missing_or_empty("bam_paired", units, wildcards.sample, wildcards.unit):
         return expand(
             "results/fastq/{sample}-{unit}.{read}.fq.gz",
             sample=wildcards.sample,

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -92,7 +92,6 @@ def is_single_end(sample, unit):
         bam_paired_not_present = pd.isnull(units.loc[(sample, unit), "bam_paired"])
     else:
         bam_paired_not_present = True
-    bam_paired_not_present = pd.isnull(units.loc[(sample, unit), "bam_paired"])
     fq2_not_present = pd.isnull(units.loc[(sample, unit), "fq2"])
     return fq2_not_present and bam_paired_not_present
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -88,12 +88,7 @@ def get_model(wildcards):
 
 def is_single_end(sample, unit):
     """Determine whether unit is single-end."""
-    if "bam_paired" in units.columns:
-        bam_paired_not_present = pd.isnull(units.loc[(sample, unit), "bam_paired"])
-    else:
-        bam_paired_not_present = True
-    fq2_not_present = pd.isnull(units.loc[(sample, unit), "fq2"])
-    return fq2_not_present and bam_paired_not_present
+    return column_missing_or_empty("fq2", units, sample, unit) and column_missing_or_empty("bam_paired", units, sample, unit)
 
 
 def get_fastqs(wildcards):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -88,6 +88,10 @@ def get_model(wildcards):
 
 def is_single_end(sample, unit):
     """Determine whether unit is single-end."""
+    if 'bam_paired' in units.columns:
+        bam_paired_not_present = pd.isnull(units.loc[(sample, unit), "bam_paired"])
+    else:
+        bam_paired_not_present = True
     bam_paired_not_present = pd.isnull(units.loc[(sample, unit), "bam_paired"])
     fq2_not_present = pd.isnull(units.loc[(sample, unit), "fq2"])
     return fq2_not_present and bam_paired_not_present
@@ -95,9 +99,9 @@ def is_single_end(sample, unit):
 
 def get_fastqs(wildcards):
     """Get raw FASTQ files from unit sheet."""
-    if not pd.isnull(units.loc[(wildcards.sample, wildcards.unit), "bam_single"]):
+    if 'bam_single' in units.columns and not pd.isnull(units.loc[(wildcards.sample, wildcards.unit), "bam_single"]):
         return f"results/fastq/{wildcards.sample}-{wildcards.unit}.fq.gz"
-    elif not pd.isnull(units.loc[(wildcards.sample, wildcards.unit), "bam_paired"]):
+    elif 'bam_paired' in units.columns and not pd.isnull(units.loc[(wildcards.sample, wildcards.unit), "bam_paired"]):
         fqfrombam1 = f"results/fastq/{wildcards.sample}-{wildcards.unit}.1.fq.gz"
         fqfrombam2 = f"results/fastq/{wildcards.sample}-{wildcards.unit}.2.fq.gz"
         return [fqfrombam1, fqfrombam2]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -98,9 +98,7 @@ def is_single_end(sample, unit):
 
 def get_fastqs(wildcards):
     """Get raw FASTQ files from unit sheet."""
-    if "bam_single" in units.columns and not pd.isnull(
-        units.loc[(wildcards.sample, wildcards.unit), "bam_single"]
-    ):
+    if column_missing_or_empty("bam_single", units, wildcards.sample, wildcards.unit):
         return f"results/fastq/{wildcards.sample}-{wildcards.unit}.fq.gz"
     elif "bam_paired" in units.columns and not pd.isnull(
         units.loc[(wildcards.sample, wildcards.unit), "bam_paired"]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -85,6 +85,12 @@ def get_model(wildcards):
         return {"full": None}
     return config["diffexp"]["models"][wildcards.model]
 
+def column_missing_or_empty(column_name, dataframe, sample, unit):
+    if column_name in dataframe.columns:
+        return pd.isnull(dataframe.loc[(sample, unit), column_name])
+    else:
+        return True
+
 
 def is_single_end(sample, unit):
     """Determine whether unit is single-end."""


### PR DESCRIPTION
This PR makes the workflow handle missing bam columns introduced in #94 without throwing an error.