### PR TITLE
fix: Move signed_pi_value_* columns to the end and move non primary variable columns to detail mode

### DIFF
--- a/workflow/resources/datavzrd/diffexp-template.yaml
+++ b/workflow/resources/datavzrd/diffexp-template.yaml
@@ -147,8 +147,20 @@ views:
                 - -1
                 - 0
                 - 1
-        regex('^b_(?!.*_se$)'):
-          display-mode: normal
+        ?f"regex('^b_{params.primary_variable}(?!.*_se$)')":
+          plot:
+            heatmap:
+              scale: linear
+              range:
+                - "#e6550d"
+                - "white"
+                - "#6baed6"
+              domain:
+                - -1
+                - 0
+                - 1
+        ?f"regex('^b_(?!{params.primary_variable})(?!.*_se$)')":
+          display-mode: detail
           plot:
             heatmap:
               scale: linear

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -103,7 +103,9 @@ rule diffexp_datavzrd:
         model=get_model,
         offer_excel=lookup(within=config, dpath="report/offer_excel", default=False),
         samples=get_model_samples,
-        primary_variable=lambda wildcards: config["diffexp"]["models"][wildcards.model]["primary_variable"],
+        primary_variable=lambda wildcards: config["diffexp"]["models"][
+            wildcards.model
+        ]["primary_variable"],
     wrapper:
         "v3.13.8/utils/datavzrd"
 

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -103,6 +103,7 @@ rule diffexp_datavzrd:
         model=get_model,
         offer_excel=lookup(within=config, dpath="report/offer_excel", default=False),
         samples=get_model_samples,
+        primary_variable=lambda wildcards: config["diffexp"]["models"][wildcards.model]["primary_variable"],
     wrapper:
         "v3.13.8/utils/datavzrd"
 

--- a/workflow/rules/meta_comparisons.smk
+++ b/workflow/rules/meta_comparisons.smk
@@ -32,7 +32,7 @@ rule meta_compare_enrichment:
                 within=config,
             ),
             gene_fdr=str(config["enrichment"]["goatools"]["fdr_genes"]).replace(
-                ".", "-"
+            ".", "-"
             ),
             go_term_fdr=str(config["enrichment"]["goatools"]["fdr_go_terms"]).replace(
                 ".", "-"

--- a/workflow/rules/meta_comparisons.smk
+++ b/workflow/rules/meta_comparisons.smk
@@ -32,7 +32,7 @@ rule meta_compare_enrichment:
                 within=config,
             ),
             gene_fdr=str(config["enrichment"]["goatools"]["fdr_genes"]).replace(
-            ".", "-"
+                ".", "-"
             ),
             go_term_fdr=str(config["enrichment"]["goatools"]["fdr_go_terms"]).replace(
                 ".", "-"

--- a/workflow/scripts/postprocess_diffexp.py
+++ b/workflow/scripts/postprocess_diffexp.py
@@ -14,10 +14,10 @@ def process_columns(df):
 
 
 def sort_columns(df, matching_columns):
-    b_column_order = [f"{prefix}{suffix}" for prefix in matching_columns for suffix in [
-        '_lower', '', '_upper', '_se']]
-    other_columns = [col for col in df.columns if not col.startswith('b_')]
-    return df[other_columns + b_column_order]
+    b_column_order = [f"{prefix}{suffix}" for prefix in matching_columns for suffix in ['_lower', '', '_upper', '_se']]
+    signed_pi_columns = [col for col in df.columns if col.startswith('signed_pi_value')]
+    other_columns = [col for col in df.columns if not col.startswith('b_') and not col.startswith('signed_pi_value')]
+    return df[other_columns + b_column_order + signed_pi_columns]
 
 
 def sort_rows(df):

--- a/workflow/scripts/sleuth-diffexp.R
+++ b/workflow/scripts/sleuth-diffexp.R
@@ -117,6 +117,14 @@ write_results <- function(so, mode, output, output_all) {
 	              # e.g. useful for GSEA ranking
 	              mutate( !!signed_pi_col_name := -log10(pval) * !!sym(beta_col_name) )
       }
+
+      # Reorder the columns so that "signed_pi_value_*" columns are at the end
+      all <- all %>%
+          select(
+            -starts_with("signed_pi_value"),
+            starts_with("signed_pi_value")
+          )
+
       # saving volcano plots
       marrange_volcano <- marrangeGrob(grobs=volcano_list, nrow=1, ncol=1, top = NULL)
       ggsave(snakemake@output[["volcano_plots"]], plot = marrange_volcano, width = 14)

--- a/workflow/scripts/sleuth-diffexp.R
+++ b/workflow/scripts/sleuth-diffexp.R
@@ -118,13 +118,6 @@ write_results <- function(so, mode, output, output_all) {
 	              mutate( !!signed_pi_col_name := -log10(pval) * !!sym(beta_col_name) )
       }
 
-      # Reorder the columns so that "signed_pi_value_*" columns are at the end
-      all <- all %>%
-          select(
-            -starts_with("signed_pi_value"),
-            starts_with("signed_pi_value")
-          )
-
       # saving volcano plots
       marrange_volcano <- marrangeGrob(grobs=volcano_list, nrow=1, ncol=1, top = NULL)
       ggsave(snakemake@output[["volcano_plots"]], plot = marrange_volcano, width = 14)


### PR DESCRIPTION
This PR moves all columns starting with  signed_pi_value_* to the end of the resulting datavzrd table.