### PR TITLE
perf: Update to latest datavzrd wrapper version

### DIFF
--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -74,7 +74,7 @@ rule spia_datavzrd:
         offer_excel=lookup(within=config, dpath="report/offer_excel", default=False),
         pathway_db=config["enrichment"]["spia"]["pathway_database"],
     wrapper:
-        "v4.4.0/utils/datavzrd"
+        "v4.6.0/utils/datavzrd"
 
 
 # Generating Differential Expression Datavzrd Report
@@ -107,7 +107,7 @@ rule diffexp_datavzrd:
             wildcards.model
         ]["primary_variable"],
     wrapper:
-        "v4.4.0/utils/datavzrd"
+        "v4.6.0/utils/datavzrd"
 
 
 # Generating GO Enrichment Datavzrd Report
@@ -143,7 +143,7 @@ rule go_enrichment_datavzrd:
         offer_excel=lookup(within=config, dpath="report/offer_excel", default=False),
         samples=get_model_samples,
     wrapper:
-        "v4.4.0/utils/datavzrd"
+        "v4.6.0/utils/datavzrd"
 
 
 # Generating Meta Comparison Datavzrd Reports
@@ -172,7 +172,7 @@ rule meta_compare_datavzrd:
     log:
         "logs/datavzrd-report/meta_comp_{method}.{meta_comp}.log",
     wrapper:
-        "v4.4.0/utils/datavzrd"
+        "v4.6.0/utils/datavzrd"
 
 
 # Generating Input Datavzrd Reports
@@ -197,4 +197,4 @@ rule inputs_datavzrd:
     log:
         "logs/datavzrd-report/{input}_datavzrd.log",
     wrapper:
-        "v4.4.0/utils/datavzrd"
+        "v4.6.0/utils/datavzrd"


### PR DESCRIPTION
This wrapper removes the resize option from composite plots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `datavzrd` utility to version `v4.6.0`, enhancing performance and functionality across multiple rules.
  
- **Bug Fixes**
	- Resolved issues related to the previous version of the `datavzrd` utility, ensuring improved reliability in rule execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->