### PR TITLE
fix: Update max in memory rows for diffexp report

### DIFF
--- a/workflow/resources/datavzrd/diffexp-template.yaml
+++ b/workflow/resources/datavzrd/diffexp-template.yaml
@@ -1,5 +1,5 @@
 __use_yte__: true
-max-in-memory-rows: 30000
+max-in-memory-rows: 42000
 
 name: ?f"Differential expression analysis for model {wildcards.model}"
 datasets:

--- a/workflow/resources/datavzrd/diffexp-template.yaml
+++ b/workflow/resources/datavzrd/diffexp-template.yaml
@@ -1,5 +1,5 @@
 __use_yte__: true
-max-in-memory-rows: 15000
+max-in-memory-rows: 30000
 
 name: ?f"Differential expression analysis for model {wildcards.model}"
 datasets:


### PR DESCRIPTION
This PR increases the maximum in memory genes/transcripts for the diffexp datavzrd report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Increased capacity for handling larger datasets in memory by adjusting the `max-in-memory-rows` parameter from 15,000 to 42,000.

- **Bug Fixes**
	- No bug fixes were included in this release.

- **Documentation**
	- Configuration file structure remains unchanged, ensuring clarity in dataset definitions and views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->