### PR TITLE
fix: Convert pval and qval to heatmap

### DIFF
--- a/workflow/resources/datavzrd/diffexp-template.yaml
+++ b/workflow/resources/datavzrd/diffexp-template.yaml
@@ -211,18 +211,28 @@ views:
               url: "http://www.ensembl.org/Homo_sapiens/Gene/Summary?g={target_id}"
         pval:
           plot:
-            bars:
+            heatmap:
               scale: linear
+              range:
+                - "#a1d99b"
+                - "white"
+                - "#fdae6b"
               domain:
-                - 0.0
-                - 1.0
+                - 0
+                - 0.05
+                - 0.25
         qval:
           plot:
-            bars:
+            heatmap:
               scale: linear
+              range:
+                - "#a1d99b"
+                - "white"
+                - "#fdae6b"
               domain:
-                - 0.0
-                - 1.0
+                - 0
+                - 0.05
+                - 0.25
         test_stat:
           display-mode: hidden 
         rss:


### PR DESCRIPTION
This PR converts pval and qval in the transcripts view of the diffexp report from bar plots to heatmaps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visualization of statistical values with heatmap representations for `pval` and `qval` in both `transcripts` and `genes_aggregated` datasets.
	- Updated domain values for improved clarity in significance levels.

These changes provide a more detailed and visually informative way to interpret data significance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->