### PR TITLE
fix: Update to latest datavzrd wrapper

### DIFF
--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -74,7 +74,7 @@ rule spia_datavzrd:
         offer_excel=lookup(within=config, dpath="report/offer_excel", default=False),
         pathway_db=config["enrichment"]["spia"]["pathway_database"],
     wrapper:
-        "v4.7.7/utils/datavzrd"
+        "v4.7.8/utils/datavzrd"
 
 
 # Generating Differential Expression Datavzrd Report
@@ -107,7 +107,7 @@ rule diffexp_datavzrd:
             wildcards.model
         ]["primary_variable"],
     wrapper:
-        "v4.7.7/utils/datavzrd"
+        "v4.7.8/utils/datavzrd"
 
 
 # Generating GO Enrichment Datavzrd Report
@@ -143,7 +143,7 @@ rule go_enrichment_datavzrd:
         offer_excel=lookup(within=config, dpath="report/offer_excel", default=False),
         samples=get_model_samples,
     wrapper:
-        "v4.7.7/utils/datavzrd"
+        "v4.7.8/utils/datavzrd"
 
 
 # Generating Meta Comparison Datavzrd Reports
@@ -172,7 +172,7 @@ rule meta_compare_datavzrd:
     log:
         "logs/datavzrd-report/meta_comp_{method}.{meta_comp}.log",
     wrapper:
-        "v4.7.7/utils/datavzrd"
+        "v4.7.8/utils/datavzrd"
 
 
 # Generating Input Datavzrd Reports
@@ -197,4 +197,4 @@ rule inputs_datavzrd:
     log:
         "logs/datavzrd-report/{input}_datavzrd.log",
     wrapper:
-        "v4.7.7/utils/datavzrd"
+        "v4.7.8/utils/datavzrd"

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -74,7 +74,7 @@ rule spia_datavzrd:
         offer_excel=lookup(within=config, dpath="report/offer_excel", default=False),
         pathway_db=config["enrichment"]["spia"]["pathway_database"],
     wrapper:
-        "v4.7.8/utils/datavzrd"
+        "v5.0.1/utils/datavzrd"
 
 
 # Generating Differential Expression Datavzrd Report
@@ -107,7 +107,7 @@ rule diffexp_datavzrd:
             wildcards.model
         ]["primary_variable"],
     wrapper:
-        "v4.7.8/utils/datavzrd"
+        "v5.0.1/utils/datavzrd"
 
 
 # Generating GO Enrichment Datavzrd Report
@@ -143,7 +143,7 @@ rule go_enrichment_datavzrd:
         offer_excel=lookup(within=config, dpath="report/offer_excel", default=False),
         samples=get_model_samples,
     wrapper:
-        "v4.7.8/utils/datavzrd"
+        "v5.0.1/utils/datavzrd"
 
 
 # Generating Meta Comparison Datavzrd Reports
@@ -172,7 +172,7 @@ rule meta_compare_datavzrd:
     log:
         "logs/datavzrd-report/meta_comp_{method}.{meta_comp}.log",
     wrapper:
-        "v4.7.8/utils/datavzrd"
+        "v5.0.1/utils/datavzrd"
 
 
 # Generating Input Datavzrd Reports
@@ -197,4 +197,4 @@ rule inputs_datavzrd:
     log:
         "logs/datavzrd-report/{input}_datavzrd.log",
     wrapper:
-        "v4.7.8/utils/datavzrd"
+        "v5.0.1/utils/datavzrd"

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -74,7 +74,7 @@ rule spia_datavzrd:
         offer_excel=lookup(within=config, dpath="report/offer_excel", default=False),
         pathway_db=config["enrichment"]["spia"]["pathway_database"],
     wrapper:
-        "v4.7.2/utils/datavzrd"
+        "v4.7.7/utils/datavzrd"
 
 
 # Generating Differential Expression Datavzrd Report
@@ -107,7 +107,7 @@ rule diffexp_datavzrd:
             wildcards.model
         ]["primary_variable"],
     wrapper:
-        "v4.7.2/utils/datavzrd"
+        "v4.7.7/utils/datavzrd"
 
 
 # Generating GO Enrichment Datavzrd Report
@@ -143,7 +143,7 @@ rule go_enrichment_datavzrd:
         offer_excel=lookup(within=config, dpath="report/offer_excel", default=False),
         samples=get_model_samples,
     wrapper:
-        "v4.7.2/utils/datavzrd"
+        "v4.7.7/utils/datavzrd"
 
 
 # Generating Meta Comparison Datavzrd Reports
@@ -172,7 +172,7 @@ rule meta_compare_datavzrd:
     log:
         "logs/datavzrd-report/meta_comp_{method}.{meta_comp}.log",
     wrapper:
-        "v4.7.2/utils/datavzrd"
+        "v4.7.7/utils/datavzrd"
 
 
 # Generating Input Datavzrd Reports
@@ -197,4 +197,4 @@ rule inputs_datavzrd:
     log:
         "logs/datavzrd-report/{input}_datavzrd.log",
     wrapper:
-        "v4.7.2/utils/datavzrd"
+        "v4.7.7/utils/datavzrd"


### PR DESCRIPTION
A quick PR to update to the latest datavzrd wrapper. This should also fix ports of the CI failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the utility wrapper for report generation to version 5.0.1, enhancing performance and functionality across various data processing rules.

- **Bug Fixes**
	- No changes to input/output structures or logging mechanisms, ensuring a consistent user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->