### PR TITLE
fix: use latest stable datavzrd, fixing a bug with numpy values in configs; increase default ensembl release version to 113 (112 currently has biomart issues)

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -15,7 +15,7 @@ resources:
   ref:
     # ensembl species name
     species: homo_sapiens
-    # ensembl release version 
+    # ensembl release version
     release: "113"
     # genome build
     build: GRCh38

--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -15,7 +15,7 @@ resources:
   ref:
     # ensembl species name
     species: homo_sapiens
-    # ensembl release version
+    # ensembl release version 
     release: "113"
     # genome build
     build: GRCh38

--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -16,7 +16,7 @@ resources:
     # ensembl species name
     species: homo_sapiens
     # ensembl release version
-    release: "112"
+    release: "113"
     # genome build
     build: GRCh38
     # pfam release to use for annotation of domains in differential splicing analysis

--- a/.test/three_prime/config/config.yaml
+++ b/.test/three_prime/config/config.yaml
@@ -16,7 +16,7 @@ resources:
     # ensembl species name
     species: homo_sapiens
     # ensembl release version
-    release: "112"
+    release: "113"
     # genome build
     build: GRCh38
     # pfam release to use for annotation of domains in differential splicing analysis

--- a/workflow/resources/datavzrd/diffexp-template.yaml
+++ b/workflow/resources/datavzrd/diffexp-template.yaml
@@ -164,7 +164,7 @@ views:
         regex('^b_.*_se$'):
           display-mode: hidden
         ?for sample in params.samples:
-          ?f"{sample}":
+          ?sample:
             display-mode: hidden
   volcano-plots:
     dataset: genes_representative
@@ -283,7 +283,7 @@ views:
         regex('^b_.*_se$'):
           display-mode: hidden
         ?for sample in params.samples:
-          ?f"{sample}":
+          ?sample:
             display-mode: hidden
   genes_aggregated:
     dataset: genes_aggregated
@@ -317,7 +317,7 @@ views:
                 - 0.0
                 - 1.0
         ?for sample in params.samples:
-          ?f"{sample}":
+          ?sample:
             display-mode: hidden
   logcount_matrix:    
     dataset: logcount_matrix
@@ -331,7 +331,7 @@ views:
         gene:
           display-mode: normal
         ?for sample in params.samples:
-          ?f"{sample}":
+          ?sample:
             display-mode: normal
             plot:
               heatmap:

--- a/workflow/resources/datavzrd/diffexp-template.yaml
+++ b/workflow/resources/datavzrd/diffexp-template.yaml
@@ -164,7 +164,7 @@ views:
         regex('^b_.*_se$'):
           display-mode: hidden
         ?for sample in params.samples:
-          ?sample:
+          ?f"{sample}":
             display-mode: hidden
   volcano-plots:
     dataset: genes_representative
@@ -283,7 +283,7 @@ views:
         regex('^b_.*_se$'):
           display-mode: hidden
         ?for sample in params.samples:
-          ?sample:
+          ?f"{sample}":
             display-mode: hidden
   genes_aggregated:
     dataset: genes_aggregated
@@ -317,7 +317,7 @@ views:
                 - 0.0
                 - 1.0
         ?for sample in params.samples:
-          ?sample:
+          ?f"{sample}":
             display-mode: hidden
   logcount_matrix:    
     dataset: logcount_matrix
@@ -331,7 +331,7 @@ views:
         gene:
           display-mode: normal
         ?for sample in params.samples:
-          ?sample:
+          ?f"{sample}":
             display-mode: normal
             plot:
               heatmap:

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -74,7 +74,7 @@ rule spia_datavzrd:
         offer_excel=lookup(within=config, dpath="report/offer_excel", default=False),
         pathway_db=config["enrichment"]["spia"]["pathway_database"],
     wrapper:
-        "v5.0.1/utils/datavzrd"
+        "v5.2.1/utils/datavzrd"
 
 
 # Generating Differential Expression Datavzrd Report
@@ -107,7 +107,7 @@ rule diffexp_datavzrd:
             wildcards.model
         ]["primary_variable"],
     wrapper:
-        "v5.0.1/utils/datavzrd"
+        "v5.2.1/utils/datavzrd"
 
 
 # Generating GO Enrichment Datavzrd Report
@@ -143,7 +143,7 @@ rule go_enrichment_datavzrd:
         offer_excel=lookup(within=config, dpath="report/offer_excel", default=False),
         samples=get_model_samples,
     wrapper:
-        "v5.0.1/utils/datavzrd"
+        "v5.2.1/utils/datavzrd"
 
 
 # Generating Meta Comparison Datavzrd Reports
@@ -172,7 +172,7 @@ rule meta_compare_datavzrd:
     log:
         "logs/datavzrd-report/meta_comp_{method}.{meta_comp}.log",
     wrapper:
-        "v5.0.1/utils/datavzrd"
+        "v5.2.1/utils/datavzrd"
 
 
 # Generating Input Datavzrd Reports
@@ -197,4 +197,4 @@ rule inputs_datavzrd:
     log:
         "logs/datavzrd-report/{input}_datavzrd.log",
     wrapper:
-        "v5.0.1/utils/datavzrd"
+        "v5.2.1/utils/datavzrd"

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -74,7 +74,7 @@ rule spia_datavzrd:
         offer_excel=lookup(within=config, dpath="report/offer_excel", default=False),
         pathway_db=config["enrichment"]["spia"]["pathway_database"],
     wrapper:
-        "v5.2.1/utils/datavzrd"
+        "v5.5.0/utils/datavzrd"
 
 
 # Generating Differential Expression Datavzrd Report
@@ -107,7 +107,7 @@ rule diffexp_datavzrd:
             wildcards.model
         ]["primary_variable"],
     wrapper:
-        "v5.2.1/utils/datavzrd"
+        "v5.5.0/utils/datavzrd"
 
 
 # Generating GO Enrichment Datavzrd Report
@@ -143,7 +143,7 @@ rule go_enrichment_datavzrd:
         offer_excel=lookup(within=config, dpath="report/offer_excel", default=False),
         samples=get_model_samples,
     wrapper:
-        "v5.2.1/utils/datavzrd"
+        "v5.5.0/utils/datavzrd"
 
 
 # Generating Meta Comparison Datavzrd Reports
@@ -172,7 +172,7 @@ rule meta_compare_datavzrd:
     log:
         "logs/datavzrd-report/meta_comp_{method}.{meta_comp}.log",
     wrapper:
-        "v5.2.1/utils/datavzrd"
+        "v5.5.0/utils/datavzrd"
 
 
 # Generating Input Datavzrd Reports
@@ -197,4 +197,4 @@ rule inputs_datavzrd:
     log:
         "logs/datavzrd-report/{input}_datavzrd.log",
     wrapper:
-        "v5.2.1/utils/datavzrd"
+        "v5.5.0/utils/datavzrd"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the Ensembl reference data version from 112 to 113 for improved genomic annotations.
	- Enhanced report generation in the bioinformatics workflow with an updated utility version.

- **Bug Fixes**
	- Ensured the integrity of the workflow by maintaining the structure and functionality while updating parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->