### PR TITLE
refactor: Add kallisto parameter validation for 3' prime experiments in units sheet

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -211,10 +211,16 @@ def kallisto_quant_input(wildcards):
 def kallisto_params(wildcards, input):
     extra = config["params"]["kallisto"]
     if len(input.fastq) == 1 or is_3prime_experiment:
+        unit = units.loc[(wildcards.sample, wildcards.unit)]
+        if unit.fragment_len_mean == "" or unit.fragment_len_sd == "":
+            raise ValueError(
+                f"Missing required fragment length parameters for sample '{wildcards.sample}', unit '{wildcards.unit}'. "
+                f"For 3' prime experiments or single-end reads, both 'fragment_len_mean' and 'fragment_len_sd' must be defined. "
+            )
         extra += " --single --single-overhang --pseudobam"
         extra += (
-            " --fragment-length {unit.fragment_len_mean} " "--sd {unit.fragment_len_sd}"
-        ).format(unit=units.loc[(wildcards.sample, wildcards.unit)])
+            f" --fragment-length {unit.fragment_len_mean} --sd {unit.fragment_len_sd}"
+        )
     else:
         extra += " --fusion"
     return extra

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -214,8 +214,8 @@ def kallisto_params(wildcards, input):
         unit = units.loc[(wildcards.sample, wildcards.unit)]
         if unit.fragment_len_mean == "" or unit.fragment_len_sd == "":
             raise ValueError(
-                f"Missing required fragment length parameters for sample '{wildcards.sample}', unit '{wildcards.unit}'. "
-                f"For 3' prime experiments or single-end reads, both 'fragment_len_mean' and 'fragment_len_sd' must be defined. "
+                f"Missing required fragment length parameter columns for sample '{wildcards.sample}', unit '{wildcards.unit}' in the units sheet. "
+                f"For 3-prime experiments and single-end reads, both 'fragment_len_mean' and 'fragment_len_sd' must be defined. "
             )
         extra += " --single --single-overhang --pseudobam"
         extra += (


### PR DESCRIPTION
Improved robustness of the function by checking that 'fragment_len_mean' and 'fragment_len_sd' are defined as non-empty strings for 3' prime experiments. 
Enhanced error messaging with clear context and debugging information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for input validation in specific experimental setups.
- **Bug Fixes**
	- Improved robustness of the workflow by enforcing necessary conditions for parameters.
- **Refactor**
	- Updated string concatenation to f-strings for better readability and maintainability.
- **Style**
	- Minor formatting adjustments for enhanced code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->