### PR TITLE
refactor: Redirect stderr to log file for easier debugging

### DIFF
--- a/workflow/scripts/compare_diffexp.py
+++ b/workflow/scripts/compare_diffexp.py
@@ -2,6 +2,9 @@ import pyreadr
 import polars as pl
 import polars.selectors as cs
 import altair as alt
+import sys
+
+sys.stderr = open(snakemake.log[0], "w")
 
 diffexp_x = pl.from_pandas(pyreadr.read_r(snakemake.input[0])[None]).lazy()
 diffexp_y = pl.from_pandas(pyreadr.read_r(snakemake.input[1])[None]).lazy()

--- a/workflow/scripts/compare_enrichment.py
+++ b/workflow/scripts/compare_enrichment.py
@@ -1,6 +1,9 @@
 import polars as pl
 import polars.selectors as cs
 import altair as alt
+import sys
+
+sys.stderr = open(snakemake.log[0], "w")
 
 diffexp_x = pl.read_csv(snakemake.input[0], separator="\t").lazy()
 diffexp_y = pl.read_csv(snakemake.input[1], separator="\t").lazy()

--- a/workflow/scripts/compare_pathways.py
+++ b/workflow/scripts/compare_pathways.py
@@ -1,6 +1,9 @@
 import polars as pl
 import polars.selectors as cs
 import altair as alt
+import sys
+
+sys.stderr = open(snakemake.log[0], "w")
 
 diffexp_x = pl.read_csv(snakemake.input[0], separator="\t").lazy()
 diffexp_y = pl.read_csv(snakemake.input[1], separator="\t").lazy()


### PR DESCRIPTION
This PR refactors the meta comparison scripts in the workflow to improve debugging capabilities. The change redirects stderr to the log file specified by `snakemake.log[0]`. By capturing error messages in the log file, it becomes easier to diagnose and troubleshoot issues during workflow execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error tracking by redirecting standard error output to a designated log file.