### PR TITLE
fix: Improve error handling for missing or empty column values in dataframe with duplicate definitions

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -101,7 +101,14 @@ def get_model(wildcards):
 
 def column_missing_or_empty(column_name, dataframe, sample, unit):
     if column_name in dataframe.columns:
-        return pd.isnull(dataframe.loc[(sample, unit), column_name])
+        result = pd.isnull(dataframe.loc[(sample, unit), column_name])
+        try:
+            return bool(result)
+        except ValueError:
+            raise ValueError(
+                f"Expected a single value for sample '{sample}', unit '{unit}' "
+                f"in column '{column_name}', but got multiple values."
+            )
     else:
         return True
 


### PR DESCRIPTION
This pull request includes an important change to the `column_missing_or_empty` function in the `workflow/rules/common.smk` file to handle cases where multiple values are returned (caused by duplicate definitions in the units sheet), which previously caused an error that was not helpful at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error feedback to provide clearer, more descriptive notifications when input data does not meet expected conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->