### PR TITLE
fix: move summing of go-term fold changes out of log-space

### DIFF
--- a/workflow/scripts/postprocess_go_enrichment.py
+++ b/workflow/scripts/postprocess_go_enrichment.py
@@ -25,7 +25,8 @@ def extract_study_items(value):
 
 
 def calculate_sums(parsed_terms):
-    return sum(2**abs(item["value"]) for item in parsed_terms).log(base=2)
+    number_of_genes=len(parsed_terms)
+    return (sum(2**abs(item["value"]) for item in parsed_terms)/number_of_genes).log(base=2)
 
 
 # Load data

--- a/workflow/scripts/postprocess_go_enrichment.py
+++ b/workflow/scripts/postprocess_go_enrichment.py
@@ -26,7 +26,7 @@ def extract_study_items(value):
 
 def calculate_sums(parsed_terms):
     number_of_genes=len(parsed_terms)
-    return (sum(2**abs(item["value"]) for item in parsed_terms)/number_of_genes).log(base=2)
+    return sum(2**abs(item["value"]) for item in parsed_terms)/number_of_genes
 
 
 # Load data
@@ -65,6 +65,7 @@ if not df_merged.is_empty():
         [
             pl.col("study_items")
             .map_elements(lambda x: calculate_sums(extract_study_items(x)))
+            .log(base=2)
             .alias("effect")
         ]
     )

--- a/workflow/scripts/postprocess_go_enrichment.py
+++ b/workflow/scripts/postprocess_go_enrichment.py
@@ -25,7 +25,7 @@ def extract_study_items(value):
 
 
 def calculate_sums(parsed_terms):
-    return sum(2^abs(item["value"]) for item in parsed_terms).log(base=2)
+    return sum(2**abs(item["value"]) for item in parsed_terms).log(base=2)
 
 
 # Load data

--- a/workflow/scripts/postprocess_go_enrichment.py
+++ b/workflow/scripts/postprocess_go_enrichment.py
@@ -25,7 +25,7 @@ def extract_study_items(value):
 
 
 def calculate_sums(parsed_terms):
-    return sum(abs(item["value"]) for item in parsed_terms)
+    return sum(2^abs(item["value"]) for item in parsed_terms).log(base=2)
 
 
 # Load data


### PR DESCRIPTION
As [discussed in a separate pull request](https://github.com/snakemake-workflows/rna-seq-kallisto-sleuth/pull/136#discussion_r1983484603), it seems like we are currently multiplying fold changes across the genes within a GO term, as we are adding up `log2()` transformations of the fold changes. To get a sum instead of a product, we have to first take `2^<log2()-value>`. And if we want to end up with a log2-value of the sum, we afterwards have to take the `log2()` again. This is what this pull request suggests.

Not sure though, if this is exactly what we want. Two things we might do differently are:
1. We might want to leave the fold change in non-log space. But thinking about this again, we need log2 fold changes for the (signed) pi value calculation, right?
2. We might want to normalize for the number of genes in a GO term. Otherwise, a ranking of GO terms based on the signed pi value will easily be dominated by high level GO terms that simply encompass a lot of genes. I'll put in a review comment with the respective suggestion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Updated the calculation logic in the analysis process to deliver more nuanced and refined aggregated metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->