### PR TITLE
fix: Add support for Drosophila melanogaster

### DIFF
--- a/workflow/scripts/get-transcript-info.R
+++ b/workflow/scripts/get-transcript-info.R
@@ -90,7 +90,7 @@ wanted_attributes <- c(
 
 
 three_prime_attributes <- c(
-  "ensembl_transcript_id_version",
+  use_if_available("ensembl_transcript_id_version", available_attributes),
   "chromosome_name",
   "transcript_length",
   "strand"
@@ -172,7 +172,7 @@ other_annotations <- all_annotations |>
   # for non-3-prime kallisto-sleuth input
   filter(!str_detect(chromosome_name, "patch|PATCH")) |>
   select(-c(chromosome_name, sleuth_attributes)) |>
-  rename(transcript = ensembl_transcript_id_version) |>
+  rename(any_of(c(transcript = "ensembl_transcript_id_version"))) |>
   mutate(
     strand = case_match(
         strand,

--- a/workflow/scripts/postprocess_go_enrichment.py
+++ b/workflow/scripts/postprocess_go_enrichment.py
@@ -16,8 +16,8 @@ def extract_study_items(value):
         data = []
         for gene_value in gene_values:
             parts = gene_value.split(":")
-            gene = parts[0]
-            val = float(parts[1])
+            gene = parts[-2]
+            val = float(parts[-1])
             data.append({"gene": gene, "value": val})
         return data
     else:


### PR DESCRIPTION
I noticed two errors that occured while working with RNA-Seq data from Drosophila melanogaster and tried to fix them:

[1](https://github.com/snakemake-workflows/rna-seq-kallisto-sleuth/commit/698a4790b51cb25827cfc4c7769efe08b13ace19). Gene names for the fruit fly can sometimes have a colon in them, when belonging to a gene family (e.g. His4:CG33869 and His4:CG31611). This leads to an error when selecting the correct name and value in postprocess_go_enrichment.py as they are also separated by a colon. The separation then results in three parts (His4, CG33869, 0.73842) instead of two parts.
[2](https://github.com/snakemake-workflows/rna-seq-kallisto-sleuth/commit/075315f266a2e117a3a5dd0f8f1b4c338ac7a450). For Drosophila melanogaster the "ensembl_transcript_id_version" attribute from the Ensembl mart does not exist. This attribute is part of the 3-prime attributes which (I assume?) are not needed for standard RNA-Seq analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transcript processing to dynamically detect and use available identifier attributes, enhancing output stability.
  - Enhanced gene value extraction to accurately handle varied input formats, ensuring more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->