### PR TITLE
feat: Add TPM matrix generation and integration into workflow

### DIFF
--- a/workflow/resources/datavzrd/diffexp-template.yaml
+++ b/workflow/resources/datavzrd/diffexp-template.yaml
@@ -13,6 +13,9 @@ datasets:
       link to log-count matrix:
         column: target_id
         table-row : logcount_matrix/transcript
+      link to tpm matrix:
+        column: target_id
+        table-row: tpm_matrix/transcript
       link to genes representative:
         column: ens_gene
         table-row: genes_representative/ens_gene
@@ -28,6 +31,9 @@ datasets:
       link to log-count matrix:
         column: target_id
         table-row : logcount_matrix/transcript
+      link to tpm matrix:
+        column: target_id
+        table-row: tpm_matrix/transcript
   genes_aggregated:
     path: ?input.genes_aggregated
     offer-excel: ?params.offer_excel
@@ -39,6 +45,15 @@ datasets:
       link to transcripts:
         column: transcript
         table-row: transcripts/target_id
+    separator: "\t"
+  tpm_matrix:
+    path: ?input.tpm_matrix
+    offer-excel: ?params.offer_excel
+    links:
+      link to transcripts:
+        column: transcript
+        table-row: transcripts/target_id
+        optional: true
     separator: "\t"
 default-view: genes_representative
 views:
@@ -344,3 +359,27 @@ views:
                   - -1
                   - 0
                   - 1
+  tpm_matrix:
+    dataset: tpm_matrix
+    desc: |
+      Transcript expression matrix (transcript × samples) as TPM values. TPMs are extracted from Sleuth’s normalized abundance estimates without batch correction, to preserve comparability across independent runs.
+    page-size: 25
+    render-table:
+      columns:
+        transcript:
+          display-mode: normal
+          link-to-url:
+            Ensembl:
+              url: "http://www.ensembl.org/Homo_sapiens/Gene/Summary?g={value}"
+        gene:
+          display-mode: normal
+        ?for sample in params.samples:
+          ?sample:
+            display-mode: normal
+            ellipsis: 0
+            plot:
+              heatmap:
+                scale: symlog
+                range:
+                  - "white"
+                  - "#e6550d"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -314,6 +314,7 @@ def all_input(wildcards):
                 "results/plots/qq/{model}.qq-plots.pdf",
                 "results/tables/diffexp/{model}.transcripts.diffexp.tsv",
                 "results/tables/logcount-matrix/{model}.logcount-matrix.tsv",
+                "results/tables/tpm-matrix/{model}.tpm-matrix.tsv",
                 "results/sleuth/{model}.samples.tsv",
                 "results/datavzrd-reports/diffexp-{model}",
                 "results/plots/diffexp-heatmap/{model}.diffexp-heatmap.{mode}.pdf",

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -29,6 +29,21 @@ rule postprocess_diffexp:
     script:
         "../scripts/postprocess_diffexp.py"
 
+rule postprocess_tpm_matrix:
+    input:
+        tpm="results/tables/tpm-matrix/{model}.tpm-matrix.tsv",
+        diffexp="results/tables/diffexp/{model}.genes-representative.diffexp_postprocessed.tsv",
+    output:
+        "results/tables/tpm-matrix/{model}.tpm-matrix.sorted.tsv",
+    conda:
+        "../envs/pandas.yaml"
+    params:
+        model=get_model,
+    log:
+         "logs/tables/tpm-matrix/{model}.tpm-matrix.sort.log",
+    script:
+        "../scripts/postprocess_tpm.py"
+
 
 # Postprocessing Logcount Data
 rule postprocess_logcount_matrix:
@@ -118,6 +133,7 @@ rule diffexp_datavzrd:
         config=workflow.source_path("../resources/datavzrd/diffexp-template.yaml"),
         # optional files required for rendering the given config
         logcount_matrix="results/tables/logcount-matrix/{model}.logcount-matrix_postprocessed.tsv",
+        tpm_matrix="results/tables/tpm-matrix/{model}.tpm-matrix.sorted.tsv",
         transcripts="results/tables/diffexp/{model}.transcripts.diffexp_postprocessed.tsv",
         genes_aggregated="results/tables/diffexp/{model}.genes-aggregated.diffexp.tsv",
         genes_representative="results/tables/diffexp/{model}.genes-representative.diffexp_postprocessed.tsv",

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -29,6 +29,7 @@ rule postprocess_diffexp:
     script:
         "../scripts/postprocess_diffexp.py"
 
+
 rule postprocess_tpm_matrix:
     input:
         tpm="results/tables/tpm-matrix/{model}.tpm-matrix.tsv",
@@ -40,7 +41,7 @@ rule postprocess_tpm_matrix:
     params:
         model=get_model,
     log:
-         "logs/tables/tpm-matrix/{model}.tpm-matrix.sort.log",
+        "logs/tables/tpm-matrix/{model}.tpm-matrix.sort.log",
     script:
         "../scripts/postprocess_tpm.py"
 

--- a/workflow/rules/diffexp.smk
+++ b/workflow/rules/diffexp.smk
@@ -240,6 +240,21 @@ rule logcount_matrix:
         "../scripts/sleuth-to-matrix.R"
 
 
+rule tpm_matrix:
+    input:
+        "results/sleuth/{model}.rds",
+    output:
+        "results/tables/tpm-matrix/{model}.tpm-matrix.tsv",
+    params:
+        model=get_model,
+    conda:
+        "../envs/sleuth.yaml"
+    log:
+        "logs/tables/tpm-matrix/{model}.tpm-matrix.log",
+    script:
+        "../scripts/sleuth-to-tpm-matrix.R"
+
+
 rule plot_diffexp_heatmap:
     input:
         logcountmatrix_file="results/tables/logcount-matrix/{model}.logcount-matrix.tsv",

--- a/workflow/rules/meta_comparisons.smk
+++ b/workflow/rules/meta_comparisons.smk
@@ -32,7 +32,7 @@ rule meta_compare_enrichment:
                 within=config,
             ),
             gene_fdr=str(config["enrichment"]["goatools"]["fdr_genes"]).replace(
-                ".", "-"
+            ".", "-"
             ),
             go_term_fdr=str(config["enrichment"]["goatools"]["fdr_go_terms"]).replace(
                 ".", "-"

--- a/workflow/rules/meta_comparisons.smk
+++ b/workflow/rules/meta_comparisons.smk
@@ -32,7 +32,7 @@ rule meta_compare_enrichment:
                 within=config,
             ),
             gene_fdr=str(config["enrichment"]["goatools"]["fdr_genes"]).replace(
-            ".", "-"
+                ".", "-"
             ),
             go_term_fdr=str(config["enrichment"]["goatools"]["fdr_go_terms"]).replace(
                 ".", "-"

--- a/workflow/scripts/postprocess_tpm.py
+++ b/workflow/scripts/postprocess_tpm.py
@@ -1,0 +1,21 @@
+import sys
+import pandas as pd
+
+sys.stderr = open(snakemake.log[0], "w")
+
+# Load input files
+tpm_df = pd.read_csv(snakemake.input["tpm"], sep="\t")
+diffexp_df = pd.read_csv(snakemake.input["diffexp"], sep="\t")
+
+# Match on 'transcript' column
+tpm_df["__sort_index"] = tpm_df["transcript"].map(
+    {transcript: i for i, transcript in enumerate(diffexp_df["target_id"])}
+)
+
+# Unmatched transcripts get NaN -> pushed to end
+tpm_df = tpm_df.sort_values(
+    by="__sort_index", na_position="last"
+).drop(columns="__sort_index")
+
+# Write output
+tpm_df.to_csv(snakemake.output[0], sep="\t", index=False)

--- a/workflow/scripts/sleuth-to-tpm-matrix.R
+++ b/workflow/scripts/sleuth-to-tpm-matrix.R
@@ -1,0 +1,27 @@
+log <- file(snakemake@log[[1]], open="wt")
+sink(log)
+sink(log, type="message")
+
+library("sleuth")
+library("limma")
+library("tidyverse")
+
+so <- sleuth_load(snakemake@input[[1]])
+
+# get TPM values
+tpm_matrix <- sleuth_to_matrix(so, "obs_norm", "tpm")
+
+# reorder columns to match covariates
+tpm_matrix <- tpm_matrix[, so$sample_to_covariates$sample, drop=FALSE]
+
+target_mapping <- so$target_mapping
+rownames(target_mapping) <- target_mapping$target_id
+
+# add transcript and gene information
+tpm_matrix <- rownames_to_column(as.data.frame(tpm_matrix), var="transcript") %>%
+              add_column(
+                gene = target_mapping[rownames(tpm_matrix), "ext_gene"],
+                .after = "transcript"
+              )
+
+write_tsv(tpm_matrix, snakemake@output[[1]])


### PR DESCRIPTION
This pull request introduces several changes to add support for TPM (Transcripts Per Million) matrix processing in the workflow. The most important changes include modifications to the `diffexp-template.yaml` file to include TPM matrix links and views, updates to the Snakemake rules to handle TPM matrix files, and the addition of new scripts for processing TPM data.

Fixes #145.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new transcript expression matrix dataset that displays TPM values alongside gene and transcript details, with options for Excel export and customizable visualizations such as heatmaps.
  - Enhanced the data processing pipeline to automatically generate and sort TPM matrices, integrating them seamlessly into differential expression reports.
  - Added a new script for processing TPM data in conjunction with differential expression results, improving data handling and output formatting.

- **Bug Fixes**
  - Adjusted formatting for the `gene_fdr` parameter in the `meta_compare_enrichment` rule to improve code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->