### PR TITLE
fix: use `verify_integrity=True` in pandas `set_index()` for samples and units to check for duplicates

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -9,7 +9,9 @@ from pathlib import Path
 validate(config, schema="../schemas/config.schema.yaml")
 
 samples = pd.read_csv(config["samples"], sep="\t", dtype=str, comment="#").set_index(
-    "sample", drop=False
+    "sample",
+    drop=False,
+    verify_integrity=True,
 )
 samples.index.names = ["sample_id"]
 
@@ -23,7 +25,9 @@ samples = drop_unique_cols(samples)
 validate(samples, schema="../schemas/samples.schema.yaml")
 
 units = pd.read_csv(config["units"], dtype=str, sep="\t", comment="#").set_index(
-    ["sample", "unit"], drop=False
+    ["sample", "unit"],
+    drop=False,
+    verify_integrity=True,
 )
 units.index.names = ["sample_id", "unit_id"]
 units.index = units.index.set_levels(


### PR DESCRIPTION
This does an early check of duplicates during samples.tsv and units.tsv reading, avoiding cryptic error messages downstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved data validation by ensuring that index columns in sample and unit tables are unique, preventing potential issues caused by duplicate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->