### PR TITLE
fix: make postprocess sorting work with more than one signed_pi value column

### DIFF
--- a/workflow/scripts/compare_diffexp.py
+++ b/workflow/scripts/compare_diffexp.py
@@ -4,7 +4,7 @@ import polars.selectors as cs
 import altair as alt
 import sys
 
-sys.stderr = open(snakemake.log[0], "w")
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
 
 diffexp_x = pl.from_pandas(pyreadr.read_r(snakemake.input[0])[None]).lazy()
 diffexp_y = pl.from_pandas(pyreadr.read_r(snakemake.input[1])[None]).lazy()

--- a/workflow/scripts/compare_enrichment.py
+++ b/workflow/scripts/compare_enrichment.py
@@ -3,7 +3,7 @@ import polars.selectors as cs
 import altair as alt
 import sys
 
-sys.stderr = open(snakemake.log[0], "w")
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
 
 diffexp_x = pl.read_csv(snakemake.input[0], separator="\t").lazy()
 diffexp_y = pl.read_csv(snakemake.input[1], separator="\t").lazy()

--- a/workflow/scripts/compare_pathways.py
+++ b/workflow/scripts/compare_pathways.py
@@ -3,7 +3,7 @@ import polars.selectors as cs
 import altair as alt
 import sys
 
-sys.stderr = open(snakemake.log[0], "w")
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
 
 diffexp_x = pl.read_csv(snakemake.input[0], separator="\t", null_values="NA").lazy()
 diffexp_y = pl.read_csv(snakemake.input[1], separator="\t", null_values="NA").lazy()

--- a/workflow/scripts/compose-sample-sheet.py
+++ b/workflow/scripts/compose-sample-sheet.py
@@ -1,5 +1,5 @@
 import sys
-sys.stderr = open(snakemake.log[0], "w")
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
 
 samples_ = snakemake.params.units[["sample", "unit"]].merge(snakemake.params.samples, on="sample")
 samples_["sample"] = samples_.apply(

--- a/workflow/scripts/get-sample-hist-bins.py
+++ b/workflow/scripts/get-sample-hist-bins.py
@@ -4,7 +4,7 @@ import sys
 import json
 
 
-sys.stderr = open(snakemake.log[0], "w")
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
 
 # Get the read-length
 f = open(snakemake.input["read_length"])

--- a/workflow/scripts/get_main_transcripts_per_gene_fasta.py
+++ b/workflow/scripts/get_main_transcripts_per_gene_fasta.py
@@ -2,7 +2,7 @@ import sys
 import pandas as pd
 from Bio import SeqIO
 
-sys.stderr = open(snakemake.log[0], "w")
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
 
 with open(snakemake.output[0], "w") as transcript_clean_cdna_fasta:
     all_transcripts = pd.read_csv(

--- a/workflow/scripts/goatools-go-enrichment-analysis.py
+++ b/workflow/scripts/goatools-go-enrichment-analysis.py
@@ -1,7 +1,7 @@
 import sys
 
-sys.stderr = open(snakemake.log[0], "w")
-sys.stdout = open(snakemake.log[0], "a")
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
+sys.stdout = open(snakemake.log[0], "a", buffering=1)
 
 import pandas as pd
 import matplotlib.pyplot as plt

--- a/workflow/scripts/plot-3prime-qc-histogram.py
+++ b/workflow/scripts/plot-3prime-qc-histogram.py
@@ -3,7 +3,7 @@ import pandas as pd
 import sys
 import json
 
-sys.stderr = open(snakemake.log[0], "w")
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
 
 # reading the file read length
 f = open(snakemake.input["read_length"])

--- a/workflow/scripts/plot-ind-sample-QC-histogram.py
+++ b/workflow/scripts/plot-ind-sample-QC-histogram.py
@@ -8,7 +8,7 @@ from scipy.stats import gaussian_kde
 from scipy import stats
 import sys
 import json
-sys.stderr = open(snakemake.log[0], "w")
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
 transcript_ids = snakemake.params["each_transcript"]
 
 samples = snakemake.params["samples"]

--- a/workflow/scripts/plot-pca.py
+++ b/workflow/scripts/plot-pca.py
@@ -2,7 +2,7 @@ import pandas as pd
 import altair as alt
 import sys
 
-sys.stderr = open(snakemake.log[0], "w")
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
 
 
 def plot(df, effect_x, effect_y):

--- a/workflow/scripts/plot_enrichment_pathway_scatter.py
+++ b/workflow/scripts/plot_enrichment_pathway_scatter.py
@@ -2,7 +2,7 @@ import pandas as pd
 import altair as alt
 import sys
 
-sys.stderr = open(snakemake.log[0], "w")
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
 
 
 def plot(df_plot, identifier, effect_x, effect_y, title, selector, color_scheme):

--- a/workflow/scripts/postprocess_diffexp.py
+++ b/workflow/scripts/postprocess_diffexp.py
@@ -1,3 +1,6 @@
+import sys
+sys.stderr = open(snakemake.log[0], "w")
+
 import pandas as pd
 
 

--- a/workflow/scripts/postprocess_diffexp.py
+++ b/workflow/scripts/postprocess_diffexp.py
@@ -39,7 +39,7 @@ def sort_rows(df):
     columns_with_prefix = [col for col in df.columns if col.startswith(signed_pi_start)]
 
     if len(columns_with_prefix) != 1:
-        warning.warn(
+        warnings.warn(
             f"We can only sort by one signed_pi value column, but found {len(columns_with_prefix)}\n"
             f"respective columns with prefix '{signed_pi_start}': {columns_with_prefix}\n"
             "This usually occurs, when you have more than two levels in your condition of\n"

--- a/workflow/scripts/postprocess_diffexp.py
+++ b/workflow/scripts/postprocess_diffexp.py
@@ -3,6 +3,7 @@ sys.stderr = open(snakemake.log[0], "w")
 
 import pandas as pd
 
+import warnings
 
 def process_columns(df):
     """compute confidence interval for every column starting with b_"""
@@ -38,8 +39,12 @@ def sort_rows(df):
     columns_with_prefix = [col for col in df.columns if col.startswith(signed_pi_start)]
 
     if len(columns_with_prefix) != 1:
-        raise ValueError(
-            f"Expected exactly one column starting with '{signed_pi_start}', found {len(columns_with_prefix)}"
+        warning.warn(
+            f"We can only sort by one signed_pi value column, but found {len(columns_with_prefix)}\n"
+            f"respective columns with prefix '{signed_pi_start}': {columns_with_prefix}\n"
+            "This usually occurs, when you have more than two levels in your condition of\n"
+            "interest column.\n"
+            f"We will sort by the first column found: {columns_with_prefix[0]}"
         )
 
     signed_pi_col = columns_with_prefix[0]

--- a/workflow/scripts/postprocess_diffexp.py
+++ b/workflow/scripts/postprocess_diffexp.py
@@ -1,5 +1,5 @@
 import sys
-sys.stderr = open(snakemake.log[0], "w")
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
 
 import pandas as pd
 

--- a/workflow/scripts/postprocess_go_enrichment.py
+++ b/workflow/scripts/postprocess_go_enrichment.py
@@ -1,5 +1,5 @@
 import sys
-sys.stderr = open(snakemake.log[0], "w")
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
 
 # import pandas as pd
 from ast import literal_eval as make_tuple

--- a/workflow/scripts/postprocess_go_enrichment.py
+++ b/workflow/scripts/postprocess_go_enrichment.py
@@ -1,3 +1,6 @@
+import sys
+sys.stderr = open(snakemake.log[0], "w")
+
 # import pandas as pd
 from ast import literal_eval as make_tuple
 import polars as pl

--- a/workflow/scripts/postprocess_logcount.py
+++ b/workflow/scripts/postprocess_logcount.py
@@ -1,3 +1,6 @@
+import sys
+sys.stderr = open(snakemake.log[0], "w")
+
 import pandas as pd
 
 

--- a/workflow/scripts/postprocess_logcount.py
+++ b/workflow/scripts/postprocess_logcount.py
@@ -1,5 +1,5 @@
 import sys
-sys.stderr = open(snakemake.log[0], "w")
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
 
 import pandas as pd
 

--- a/workflow/scripts/postprocess_tpm.py
+++ b/workflow/scripts/postprocess_tpm.py
@@ -1,7 +1,7 @@
 import sys
 import pandas as pd
 
-sys.stderr = open(snakemake.log[0], "w")
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
 
 # Load input files
 tpm_df = pd.read_csv(snakemake.input["tpm"], sep="\t")

--- a/workflow/scripts/remove_poly_tails.py
+++ b/workflow/scripts/remove_poly_tails.py
@@ -3,7 +3,7 @@ import re
 from Bio import SeqIO
 from Bio.Seq import Seq
 
-sys.stderr = open(snakemake.log[0], "w")
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
 
 with open(snakemake.output[0], "w") as transcript_clean_cdna_fasta:
     for seq_record in SeqIO.parse(snakemake.input["ref_fasta"], "fasta"):


### PR DESCRIPTION
The sorting via signed_pi value column will simply use the first such column for the primary variable that is found. In addition, the `postprocess_` scripts now have the boilerplate code to actually write out stderr to their respective log files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Error and warning messages are now redirected to log files with improved line-by-line flushing for better real-time tracking during script execution.
  - When multiple columns match the expected sorting prefix, the script now issues a warning and proceeds, instead of stopping with an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->