### PR TITLE
fix: set spia mem_mb to 32G and threads to 32

### DIFF
--- a/workflow/rules/enrichment.smk
+++ b/workflow/rules/enrichment.smk
@@ -24,7 +24,7 @@ rule spia:
         "logs/tables/pathways/{model}.spia-pathways.log",
     threads: 32
     resources:
-        mem_mb: 32000
+        mem_mb=32000,
     script:
         "../scripts/spia.R"
 


### PR DESCRIPTION
`spia` uses a lot of memory, and we have observed above 20G of memory usage. To be safe, we reserve a bit more. The cores we set to a power of 2, as that will often align with the number of cores available on machines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted resource allocation for the enrichment workflow to use fewer threads and set a specific memory limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->