### PR TITLE
feat!: allow to run spia on multiple pathway databases (separately)

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -100,9 +100,18 @@ enrichment:
   spia:
     # tool is only run if set to `true`
     activate: true
-    # pathway database to use in SPIA, needs to be available for
-    # the species specified by resources -> ref -> species above
-    pathway_database: "panther"
+    # pathway databases to use in SPIA
+    # The database needs to be available for the species specified by
+    # resources -> ref -> species above, which you can check via the graphite
+    # package function pathwayDatabases():
+    # https://rdrr.io/bioc/graphite/man/pathwayDatabases.html
+    # The actual list is maintained in the code (make sure to select the
+    # correct commit/version of the repository):
+    # https://github.com/sales-lab/graphite/blob/1fa6ebfb41c1cd01f8b6e7f76f45ee76a15a3450/R/fetch.R#L43
+    # Or you can look it up in the graphite documentation PDF (page 6):
+    # https://bioconductor.org/packages/release/bioc/vignettes/graphite/inst/doc/graphite.pdf
+    pathway_databases:
+      - panther
 
 meta_comparisons:
   # comparison is only run if set to `true`

--- a/.test/three_prime/config/config.yaml
+++ b/.test/three_prime/config/config.yaml
@@ -100,9 +100,18 @@ enrichment:
   spia:
     # tool is only run if set to `true`
     activate: true
-    # pathway database to use in SPIA, needs to be available for
-    # the species specified by resources -> ref -> species above
-    pathway_database: "panther"
+    # pathway databases to use in SPIA
+    # The database needs to be available for the species specified by
+    # resources -> ref -> species above, which you can check via the graphite
+    # package function pathwayDatabases():
+    # https://rdrr.io/bioc/graphite/man/pathwayDatabases.html
+    # The actual list is maintained in the code (make sure to select the
+    # correct commit/version of the repository):
+    # https://github.com/sales-lab/graphite/blob/1fa6ebfb41c1cd01f8b6e7f76f45ee76a15a3450/R/fetch.R#L43
+    # Or you can look it up in the graphite documentation PDF (page 6):
+    # https://bioconductor.org/packages/release/bioc/vignettes/graphite/inst/doc/graphite.pdf
+    pathway_databases:
+      - panther
 
 meta_comparisons:
   # comparison is only run if set to `true`

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -101,9 +101,19 @@ enrichment:
   spia:
     # tool is only run if set to `true`
     activate: false
-    # pathway database to use in SPIA, needs to be available for
-    # the species specified by resources -> ref -> species above
-    pathway_database: "reactome"
+    # pathway databases to use in SPIA
+    # The database needs to be available for the species specified by
+    # resources -> ref -> species above, which you can check via the graphite
+    # package function pathwayDatabases():
+    # https://rdrr.io/bioc/graphite/man/pathwayDatabases.html
+    # The actual list is maintained in the code (make sure to select the
+    # correct commit/version of the repository):
+    # https://github.com/sales-lab/graphite/blob/1fa6ebfb41c1cd01f8b6e7f76f45ee76a15a3450/R/fetch.R#L43
+    # Or you can look it up in the graphite documentation PDF (page 6):
+    # https://bioconductor.org/packages/release/bioc/vignettes/graphite/inst/doc/graphite.pdf
+    pathway_databases:
+      - reactome
+      - kegg
 
 meta_comparisons:
   # comparison is only run if set to `true`

--- a/workflow/resources/datavzrd/spia-template.yaml
+++ b/workflow/resources/datavzrd/spia-template.yaml
@@ -21,9 +21,9 @@ views:
           display-mode: normal
           link-to-url: 
             pathway:
-              ?if params.pathway_db == "reactome":
+              ?if wildcards.database == "reactome":
                 url: "http://reactome.org/PathwayBrowser/#/{pathway id}"
-              ?elif params.pathway_db == "panther":
+              ?elif wildcards.database == "panther":
                 url: "https://www.pantherdb.org/pathway/pathwayDiagram.jsp?catAccession={pathway id}"
               # we should add all the pathway databases that bioconductor-graphite enables (see its `pathwayDatabases()` function)
               ?else: # not sure what a good fallback would be here

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -300,10 +300,11 @@ def all_input(wildcards):
         wanted_input.extend(
             expand(
                 [
-                    "results/tables/pathways/{model}.pathways.tsv",
-                    "results/datavzrd-reports/spia-{model}/",
+                    "results/tables/pathways/{model}.{database}.pathways.tsv",
+                    "results/datavzrd-reports/spia-{model}_{database}/",
                 ],
-                model=config["diffexp"]["models"],
+                model=lookup(within=config, dpath="diffexp/models"),
+                database=lookup(within=config, dpath="enrichment/spia/pathway_databases"),
             )
         )
 
@@ -445,9 +446,23 @@ def all_input(wildcards):
             directory(
                 expand(
                     "results/datavzrd-reports/{report_type}_meta_comparison_{meta_comp}",
-                    report_type=["go_terms", "diffexp", "pathways"],
+                    report_type=["go_terms", "diffexp"],
                     meta_comp=lookup(
                         dpath="meta_comparisons/comparisons", within=config
+                    ),
+                )
+            ),
+        )
+        wanted_input.extend(
+            directory(
+                expand(
+                    "results/datavzrd-reports/pathways_meta_comparison_{meta_comp}_{database}",
+                    meta_comp=lookup(
+                        dpath="meta_comparisons/comparisons", within=config
+                    ),
+                    database=lookup(
+                        within=config,
+                        dpath="enrichment/spia/pathway_databases"
                     ),
                 )
             ),

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -304,7 +304,9 @@ def all_input(wildcards):
                     "results/datavzrd-reports/spia-{model}_{database}/",
                 ],
                 model=lookup(within=config, dpath="diffexp/models"),
-                database=lookup(within=config, dpath="enrichment/spia/pathway_databases"),
+                database=lookup(
+                    within=config, dpath="enrichment/spia/pathway_databases"
+                ),
             )
         )
 
@@ -461,8 +463,7 @@ def all_input(wildcards):
                         dpath="meta_comparisons/comparisons", within=config
                     ),
                     database=lookup(
-                        within=config,
-                        dpath="enrichment/spia/pathway_databases"
+                        within=config, dpath="enrichment/spia/pathway_databases"
                     ),
                 )
             ),

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -109,7 +109,6 @@ rule spia_datavzrd:
         "logs/datavzrd-report/spia-{model}/spia-{model}_{database}.log",
     params:
         offer_excel=lookup(within=config, dpath="report/offer_excel", default=False),
-        pathway_db=config["enrichment"]["spia"]["pathway_database"],
     wrapper:
         "v5.5.0/utils/datavzrd"
 
@@ -205,9 +204,6 @@ rule meta_compare_datavzrd:
                 method=f"{wildcards.method.capitalize()}: "
             )(wildcards),
         ),
-    params:
-        pathway_db=config["enrichment"]["spia"]["pathway_database"],
-        species=config["resources"]["ref"]["species"],
     log:
         "logs/datavzrd-report/meta_comp_{method}.{meta_comp}.log",
     wrapper:

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -65,13 +65,13 @@ rule plot_enrichment_scatter:
 
 rule plot_pathway_scatter:
     input:
-        "results/tables/pathways/{model}.pathways.tsv",
+        "results/tables/pathways/{model}.{database}.pathways.tsv",
     output:
-        "results/plots/pathways/{model}.pathways.tsv_scatter.json",
+        "results/plots/pathways/{model}.{database}.pathways.tsv_scatter.json",
     conda:
         "../envs/pystats.yaml"
     log:
-        "logs/plot_pathway_scatter-{model}/plot_pathway_scatter-{model}.log",
+        "logs/plot_pathway_scatter/{model}.{database}.pathways.tsv_scatter.log",
     params:
         identifier="Name",
         effect_x="total perturbation accumulation",
@@ -88,22 +88,25 @@ rule spia_datavzrd:
         vega_circle=workflow.source_path(
             "../resources/custom_vega_plots/circle_diagram_genes.json"
         ),
-        spia_table="results/tables/pathways/{model}.pathways.tsv",
+        spia_table="results/tables/pathways/{model}.{database}.pathways.tsv",
         vega_waterfall=workflow.source_path(
             "../resources/custom_vega_plots/waterfall_plot_study_items.json"
         ),
-        scatter="results/plots/pathways/{model}.pathways.tsv_scatter.json",
+        scatter="results/plots/pathways/{model}.{database}.pathways.tsv_scatter.json",
     output:
         report(
-            directory("results/datavzrd-reports/spia-{model}"),
+            directory("results/datavzrd-reports/spia-{model}_{database}"),
             htmlindex="index.html",
             caption="../report/spia.rst",
             category="Pathway enrichment",
             patterns=["index.html"],
-            labels={"model": "{model}"},
+            labels={
+                "model": "{model}",
+                "database": "{database}",
+            },
         ),
     log:
-        "logs/datavzrd-report/spia-{model}/spia-{model}.log",
+        "logs/datavzrd-report/spia-{model}/spia-{model}_{database}.log",
     params:
         offer_excel=lookup(within=config, dpath="report/offer_excel", default=False),
         pathway_db=config["enrichment"]["spia"]["pathway_database"],

--- a/workflow/rules/enrichment.smk
+++ b/workflow/rules/enrichment.smk
@@ -9,7 +9,7 @@ rule spia:
     input:
         samples="results/sleuth/{model}.samples.tsv",
         diffexp="results/tables/diffexp/{model}.genes-representative.diffexp.tsv",
-        spia_db="resources/spia-db.rds",
+        spia_db="resources/spia-db.{database}.rds",
         common_src=workflow.source_path("../scripts/common.R"),
     output:
         table="results/tables/pathways/{model}.{database}.pathways.tsv",

--- a/workflow/rules/enrichment.smk
+++ b/workflow/rules/enrichment.smk
@@ -12,16 +12,15 @@ rule spia:
         spia_db="resources/spia-db.rds",
         common_src=workflow.source_path("../scripts/common.R"),
     output:
-        table="results/tables/pathways/{model}.pathways.tsv",
-        plots="results/plots/pathways/{model}.spia-perturbation-plots.pdf",
+        table="results/tables/pathways/{model}.{database}.pathways.tsv",
+        plots="results/plots/pathways/{model}.{database}.spia-perturbation-plots.pdf",
     params:
         bioc_species_pkg=bioc_species_pkg,
-        pathway_db=config["enrichment"]["spia"]["pathway_database"],
-        covariate=lambda w: config["diffexp"]["models"][w.model]["primary_variable"],
+        covariate=lookup(within=config, dpath="diffexp/models/{model}/primary_variable"),
     conda:
         enrichment_env
     log:
-        "logs/tables/pathways/{model}.spia-pathways.log",
+        "logs/tables/pathways/{model}.{database}.spia-pathways.log",
     threads: 32
     resources:
         mem_mb=32000,

--- a/workflow/rules/meta_comparisons.smk
+++ b/workflow/rules/meta_comparisons.smk
@@ -57,17 +57,17 @@ rule meta_compare_enrichment:
 rule meta_compare_pathways:
     input:
         expand(
-            "results/tables/pathways/{model}.pathways.tsv",
+            "results/tables/pathways/{model}.{database}.pathways.tsv",
             model=lookup(
                 dpath="meta_comparisons/comparisons/{meta_comp}/items/*",
                 within=config,
             ),
         ),
     output:
-        "results/tables/pathways/meta_compare_{meta_comp}.tsv",
-        "results/meta_comparison/pathways/{meta_comp}.json",
+        "results/tables/pathways/meta_compare_{meta_comp}_{database}.tsv",
+        "results/meta_comparison/pathways/{meta_comp}_{database}.json",
     log:
-        "logs/meta_compare_pathways/{meta_comp}.log",
+        "logs/meta_compare_pathways/{meta_comp}_{database}.log",
     params:
         labels=lookup(
             dpath="meta_comparisons/comparisons/{meta_comp}/items",

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -119,13 +119,12 @@ rule get_spia_db:
     input:
         common_src=workflow.source_path("../scripts/common.R"),
     output:
-        "resources/spia-db.rds",
+        "resources/spia-db.{database}.rds",
     log:
-        "logs/spia-db.log",
+        "logs/spia-db.{database}.log",
     params:
         bioc_species_pkg=bioc_species_pkg,
         species=get_bioc_species_name(),
-        pathway_db=config["enrichment"]["spia"]["pathway_database"],
     conda:
         enrichment_env
     retries: 3

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -162,10 +162,12 @@ properties:
         properties:
           activate:
             type: boolean
-          pathway_database:
-            type: string
+          pathway_databases:
+            type: array
+            items:
+              type: string
         required:
-          - pathway_database
+          - pathway_databases
 
   bootstrap_plots:
     type: object

--- a/workflow/scripts/get-spia-db.R
+++ b/workflow/scripts/get-spia-db.R
@@ -11,7 +11,7 @@ library(snakemake@params[["bioc_species_pkg"]], character.only = TRUE)
 # snakemake@params[["covariate"]]
 source(snakemake@input[["common_src"]])
 
-pw_db <- snakemake@params[["pathway_db"]]
+pw_db <- snakemake@wildcards[["database"]]
 
 db <- pathways(snakemake@params[["species"]], pw_db)
 db <- convertIdentifiers(db, "ENSEMBL")

--- a/workflow/scripts/spia.R
+++ b/workflow/scripts/spia.R
@@ -10,7 +10,7 @@ library(snakemake@params[["bioc_species_pkg"]], character.only = TRUE)
 # snakemake@input[["samples"]] and snakemake@params[["covariate"]]
 source(snakemake@input[["common_src"]])
 
-pw_db <- snakemake@params[["pathway_db"]]
+pw_db <- snakemake@wildcards[["database"]]
 db <- readRDS(snakemake@input[["spia_db"]])
 
 org_db_name <- snakemake@params[["bioc_species_pkg"]]


### PR DESCRIPTION
This introduces a wildcard for the spia pathway database name and properly documents where to find the databases that can be used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using multiple pathway databases in SPIA enrichment analyses, allowing users to specify and analyze more than one database at a time.

* **Improvements**
  * Enhanced configuration files and schema to accept lists of pathway databases instead of a single entry.
  * Updated workflow and reporting to distinguish outputs by the selected pathway database, improving clarity and flexibility.
  * Expanded documentation within configuration files to guide users on database selection and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->